### PR TITLE
fix: default open on accordion

### DIFF
--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -1,22 +1,39 @@
 <template>
-  <Disclosure as="div" v-slot="{ open }" class="concrete__accordion">
+  <Disclosure
+    as="div"
+    v-slot="{ open }"
+    class="concrete__accordion"
+    :defaultOpen="defaultOpen"
+  >
     <DisclosureButton class="w-full text-left" @click="onClick(!open)">
-      <div v-if="title" class="flex items-center justify-between p-4 bg-gray-50 hover:bg-gray-100">
-          {{ title }}
-          <ChevronUpIcon
-              :class="[open && 'rotate-180 transform']"
-              class="flex-none h-5 w-5 ml-2 transition-all"
-          />
-        </div>
+      <div
+        v-if="title"
+        class="
+          flex
+          items-center
+          justify-between
+          p-4
+          bg-gray-50
+          hover:bg-gray-100
+        "
+      >
+        {{ title }}
+        <ChevronUpIcon
+          :class="[open && 'rotate-180 transform']"
+          class="flex-none h-5 w-5 ml-2 transition-all"
+        />
+      </div>
 
-        <slot v-else name="title" :open="open"/>
-
+      <slot v-else name="title" :open="open" />
     </DisclosureButton>
 
     <DisclosurePanel static>
-      <div class="overflow-hidden transition-all duration-200" :style="{ height }">
+      <div
+        class="overflow-hidden transition-all duration-200"
+        :style="{ height }"
+      >
         <div ref="content">
-          <slot :open="open"/>
+          <slot :open="open" />
         </div>
       </div>
     </DisclosurePanel>
@@ -24,14 +41,14 @@
 </template>
 
 <script setup>
-import { Disclosure, DisclosureButton, DisclosurePanel, } from '@headlessui/vue';
+import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue';
 
 import { ChevronUpIcon } from '@heroicons/vue/solid';
 import { ref } from 'vue';
 
 const props = defineProps({
   defaultOpen: { type: Boolean, default: false },
-  title: String
+  title: String,
 });
 
 const initialHeight = props.defaultOpen ? 'auto' : 0;
@@ -44,9 +61,9 @@ const onClick = (open) => {
   height.value = contentHeight + 'px';
 
   if (open) {
-    setTimeout(() => height.value = 'auto', TRANSITION_TIME);
+    setTimeout(() => (height.value = 'auto'), TRANSITION_TIME);
   } else {
-    setTimeout(() => height.value = '0');
+    setTimeout(() => (height.value = '0'));
   }
-}
+};
 </script>


### PR DESCRIPTION
fixes default open bug when setting the prop `defaultOpen` to true would cause clicks on accordion to not show/hide the panel content