### PR TITLE
Se 31 make modal accessible and enable keyboard events

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -2,7 +2,7 @@
   <transition name="modal" aria-modal="true">
     <div v-if="show"
       class="fixed w-full h-full left-0 top-0 z-50 flex items-center justify-center bg-black bg-opacity-50 transition-opacity duration-500 p-4"
-      @click.self="onClose" @keydown.esc="onClose" ref="modal">
+      @click.self="onClose" @keydown.esc="onClose" ref="modal" aria-model="true" role="dialog">
       <div class="concrete-modal max-w-full bg-white rounded shadow duration-300 ellipsis overflow-auto max-h-full"
         :class="widthClass">
 

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -2,13 +2,13 @@
   <transition name="modal" aria-modal="true">
     <div v-if="show"
       class="fixed w-full h-full left-0 top-0 z-50 flex items-center justify-center bg-black bg-opacity-50 transition-opacity duration-500"
-      @click.self="onClose" @keydown.esc="onClose" tabindex="0" ref="modal">
+      @click.self="onClose" @keydown.esc="onClose" ref="modal">
       <div class="concrete-modal max-w-full bg-white rounded shadow duration-300" :class="widthClass">
 
         <!-- header -->
         <div class="flex items-center justify-between border-b text-lg text-gray-500" :class="{ title }">
           <div class="py-4 px-6">{{ title }}</div>
-          <button v-if="closeable" class="p-4 mr-2" @click="onClose">
+          <button v-if="closeable" class="p-4 mr-2" @click="onClose" tabindex="0" @focus="focusModal">
             <CIcon type="times" size="sm" />
           </button>
         </div>
@@ -44,9 +44,11 @@ const modal = ref(null)
 
 onUpdated(() => {
   if (props.show) {
-    modal.value.focus();
+    focusModal();
   }
 });
+
+const focusModal = () => modal.value.focus();
 
 const widthClasses = {
   md: 'w-[24rem]',

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -1,15 +1,16 @@
 <template>
-  <transition name="modal" aria-modal="true">
+  <transition name="modal">
     <div v-if="show"
       class="fixed w-full h-full left-0 top-0 z-50 flex items-center justify-center bg-black bg-opacity-50 transition-opacity duration-500 p-4"
-      @click.self="onClose" @keydown.esc="onClose" ref="modal" aria-modal="true" role="dialog">
+      @click.self="onClose" @keydown.esc="onClose" aria-modal="true" role="dialog">
       <div class="concrete-modal max-w-full bg-white rounded shadow duration-300 ellipsis overflow-auto max-h-full"
         :class="widthClass">
 
         <!-- header -->
         <div class="flex items-center justify-between border-b text-lg text-gray-500" :class="{ title }">
           <div class="py-4 px-6">{{ title }}</div>
-          <button v-if="closeable" class="p-4 mr-2" @click="onClose" tabindex="0" @focus="focusModal">
+          <button v-if="closeable" class="p-4 mr-2" @click="onClose" @focus="focusModal"
+            @keydown.tab.prevent="focusModal" ref="modal" @keydown.esc="onClose">
             <CIcon type="times" size="sm" />
           </button>
         </div>
@@ -43,13 +44,15 @@ const emit = defineEmits(['close']);
 
 const modal = ref(null)
 
-watch(() => props.show, (showValue) => {
-  if (showValue) {
-    focusModal();
+onUpdated(() => {
+  if (props.show) {
+    focusModal()
   }
 });
 
-const focusModal = () => modal.value.focus();
+const focusModal = () => {
+  modal.value.focus()
+};
 
 const widthClasses = {
   md: 'w-[24rem]',

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onUpdated } from 'vue';
+import { ref, computed, watch, nextTick } from 'vue';
 import CIcon from '../Icon/Icon.vue';
 
 const props = defineProps({
@@ -44,11 +44,14 @@ const emit = defineEmits(['close']);
 
 const modal = ref(null)
 
-onUpdated(() => {
-  if (props.show) {
-    focusModal()
+watch(() => props.show, (showValue) => {
+  if (showValue) {
+    nextTick(() => {
+      focusModal();
+    });
   }
 });
+
 
 const focusModal = () => {
   modal.value.focus()

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -43,8 +43,8 @@ const emit = defineEmits(['close']);
 
 const modal = ref(null)
 
-onUpdated(() => {
-  if (props.show) {
+watch(() => props.show, (showValue) => {
+  if (showValue) {
     focusModal();
   }
 });

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -46,9 +46,7 @@ const modal = ref(null)
 
 watch(() => props.show, (showValue) => {
   if (showValue) {
-    nextTick(() => {
-      focusModal();
-    });
+    nextTick(focusModal);
   }
 });
 

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -2,7 +2,7 @@
   <transition name="modal" aria-modal="true">
     <div v-if="show"
       class="fixed w-full h-full left-0 top-0 z-50 flex items-center justify-center bg-black bg-opacity-50 transition-opacity duration-500 p-4"
-      @click.self="onClose" @keydown.esc="onClose" ref="modal" aria-model="true" role="dialog">
+      @click.self="onClose" @keydown.esc="onClose" ref="modal" aria-modal="true" role="dialog">
       <div class="concrete-modal max-w-full bg-white rounded shadow duration-300 ellipsis overflow-auto max-h-full"
         :class="widthClass">
 

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -1,9 +1,10 @@
 <template>
   <transition name="modal" aria-modal="true">
     <div v-if="show"
-      class="fixed w-full h-full left-0 top-0 z-50 flex items-center justify-center bg-black bg-opacity-50 transition-opacity duration-500"
+      class="fixed w-full h-full left-0 top-0 z-50 flex items-center justify-center bg-black bg-opacity-50 transition-opacity duration-500 p-4"
       @click.self="onClose" @keydown.esc="onClose" ref="modal">
-      <div class="concrete-modal max-w-full bg-white rounded shadow duration-300" :class="widthClass">
+      <div class="concrete-modal max-w-full bg-white rounded shadow duration-300 ellipsis overflow-auto max-h-full"
+        :class="widthClass">
 
         <!-- header -->
         <div class="flex items-center justify-between border-b text-lg text-gray-500" :class="{ title }">

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -1,19 +1,21 @@
 <template>
-  <transition name="modal">
-    <div v-if="show" class="fixed w-full h-full left-0 top-0 z-50 flex items-center justify-center bg-black bg-opacity-50 transition-opacity duration-500" @click.self="onClose">
+  <transition name="modal" aria-modal="true">
+    <div v-if="show"
+      class="fixed w-full h-full left-0 top-0 z-50 flex items-center justify-center bg-black bg-opacity-50 transition-opacity duration-500"
+      @click.self="onClose" @keydown.esc="onClose" tabindex="0" ref="modal">
       <div class="concrete-modal max-w-full bg-white rounded shadow duration-300" :class="widthClass">
 
         <!-- header -->
         <div class="flex items-center justify-between border-b text-lg text-gray-500" :class="{ title }">
           <div class="py-4 px-6">{{ title }}</div>
           <button v-if="closeable" class="p-4 mr-2" @click="onClose">
-            <CIcon type="times" size="sm"/>
+            <CIcon type="times" size="sm" />
           </button>
         </div>
 
         <!-- content -->
         <div class="p-6">
-          <slot/>
+          <slot />
         </div>
 
       </div>
@@ -22,7 +24,7 @@
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { ref, computed, onUpdated } from 'vue';
 import CIcon from '../Icon/Icon.vue';
 
 const props = defineProps({
@@ -37,6 +39,14 @@ const props = defineProps({
 });
 
 const emit = defineEmits(['close']);
+
+const modal = ref(null)
+
+onUpdated(() => {
+  if (props.show) {
+    modal.value.focus();
+  }
+});
 
 const widthClasses = {
   md: 'w-[24rem]',
@@ -53,7 +63,8 @@ const onClose = () => {
 </script>
 
 <style>
-.modal-enter-from, .modal-leave-to {
+.modal-enter-from,
+.modal-leave-to {
   opacity: 0;
 }
 


### PR DESCRIPTION
- SE-31 Make modal accessible and enable keyboard events
- SE-33 CModal - content not visible if it exceeds the height of the page

![image](https://user-images.githubusercontent.com/16907484/195826389-a98d9e28-00db-4c7f-8fe3-003a0bb6e494.png)

Was slightly tricky trying to create focusTrap within modal - without the use of plugins, vue directives, [composables](https://www.telerik.com/blogs/how-to-trap-focus-modal-vue-3) etc. Focus handler method is simple and prevents focus (key board tabbing) leaving the modal element (otherwise it would tab through forms etc in the background)