### PR TITLE
Tscsc 601 UI fixes

### DIFF
--- a/src/components/AutoComplete/AutoComplete.vue
+++ b/src/components/AutoComplete/AutoComplete.vue
@@ -40,7 +40,7 @@
           />
           <ComboboxButton
             class="absolute inset-y-0 right-0 flex items-center z-30 pr-2"
-            v-if="showUpDownChevrons"
+            v-if="showButtons"
           >
             <ChevronUpDownIcon class="w-5" :class="inputColorClass" />
           </ComboboxButton>
@@ -126,7 +126,7 @@ import { isPlainObject } from 'lodash-es';
 
 const props = defineProps({
   ...formElementProps,
-  showUpDownChevrons: { type: Boolean, default: false },
+  showButtons: { type: Boolean, default: false },
   id: { type: String, default: null },
   modelValue: [String, Object, Array],
   color: colorProp,

--- a/src/components/AutoComplete/AutoComplete.vue
+++ b/src/components/AutoComplete/AutoComplete.vue
@@ -38,7 +38,10 @@
               inputColorClass,
             ]"
           />
-          <ComboboxButton class="absolute inset-y-0 right-0 flex items-center z-30 pr-2">
+          <ComboboxButton
+            class="absolute inset-y-0 right-0 flex items-center z-30 pr-2"
+            v-if="showUpDownChevrons"
+          >
             <ChevronUpDownIcon class="w-5" :class="inputColorClass" />
           </ComboboxButton>
           <CInputAffix v-if="suffix" type="suffix">{{ suffix }}</CInputAffix>
@@ -91,7 +94,7 @@
 </template>
 
 <script setup>
-import { ChevronUpDownIcon } from '@heroicons/vue/20/solid'
+import { ChevronUpDownIcon } from '@heroicons/vue/20/solid';
 
 import { computed, ref } from 'vue';
 import {
@@ -123,7 +126,7 @@ import { isPlainObject } from 'lodash-es';
 
 const props = defineProps({
   ...formElementProps,
-
+  showUpDownChevrons: { type: Boolean, default: false },
   id: { type: String, default: null },
   modelValue: [String, Object, Array],
   color: colorProp,

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -11,9 +11,14 @@
       stacked,
       noLabel,
       expandInput: false,
+      labelOrder: reverseLabelOrder ? 1 : 0,
     }"
+    :class="{ '!justify-start': reverseLabelOrder }"
   >
-    <div class="concrete__checkbox flex">
+    <div
+      class="concrete__checkbox flex pt-1 mr-2"
+      :class="[reverseLabelOrder && 'order-1']"
+    >
       <span class="sr-only">{{ srLabel }}</span>
       <Switch
         ref="switchRef"
@@ -23,7 +28,7 @@
         class="items-center border border-gray-300"
         :class="[`h-${sized} w-${sized}`, cursorClass, bgColor]"
       >
-        <span class="flex items-center justify-center transition-opacity">
+        <span class="flex justify-center transition-opacity">
           <CheckIcon v-if="enabled" :class="checkIconClass" />
         </span>
       </Switch>
@@ -54,6 +59,7 @@ const props = defineProps({
   transparent: { type: Boolean, default: false },
   srLabel: { type: String, default: 'Switch' },
   onChange: { type: Function, default: null },
+  reverseLabelOrder: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(['update:modelValue', 'change']);

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -11,13 +11,13 @@
       stacked,
       noLabel,
       expandInput: false,
-      labelOrder: reverseLabelOrder ? 1 : 0,
+      labelOrder: reverseLabels ? 1 : 0,
     }"
-    :class="{ '!justify-start': reverseLabelOrder }"
+    :class="{ '!justify-start': reverseLabels }"
   >
     <div
       class="concrete__checkbox flex pt-1 mr-2"
-      :class="[reverseLabelOrder && 'order-1']"
+      :class="[reverseLabels && 'order-1']"
     >
       <span class="sr-only">{{ srLabel }}</span>
       <Switch
@@ -59,7 +59,7 @@ const props = defineProps({
   transparent: { type: Boolean, default: false },
   srLabel: { type: String, default: 'Switch' },
   onChange: { type: Function, default: null },
-  reverseLabelOrder: { type: Boolean, default: false },
+  reverseLabels: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(['update:modelValue', 'change']);

--- a/src/components/FormElement/FormElement.vue
+++ b/src/components/FormElement/FormElement.vue
@@ -7,7 +7,11 @@
       :class="[stackedClass, sizeClass, textSizeClass, labelOrderClass]"
       v-if="label"
     >
-      <label class="leading-4 whitespace-nowrap" :class="[lineClampClass]" :for="id">
+      <label
+        class="leading-4 whitespace-nowrap"
+        :class="[lineClampClass]"
+        :for="id"
+      >
         {{ label }}
       </label>
     </div>
@@ -43,6 +47,11 @@ const props = defineProps({
   noLabel: { type: Boolean },
   labelOrder: { type: Number },
 });
+
+const LABEL_ORDER_CLASSES = {
+  [0]: 'order-0 !basis-auto',
+  [1]: 'order-1 !basis-auto',
+};
 
 const { textSizeClass, heightClass, disabledClass } = useInputClasses(props);
 
@@ -81,6 +90,7 @@ const stackedClass = stacked
   ? 'mb-1 truncate'
   : 'flex basis-1/2 flex-col justify-center pr-6';
 
-const labelOrderClass =
-  props.labelOrder && `order-${props.labelOrder} !basis-auto`;
+const labelOrderClass = computed(() => {
+  return props.labelOrder ? LABEL_ORDER_CLASSES[props.labelOrder] : '';
+});
 </script>

--- a/src/components/FormElement/FormElement.vue
+++ b/src/components/FormElement/FormElement.vue
@@ -1,23 +1,34 @@
 <template>
-  <div class="concrete__form-element" :class="{ 'flex flex-row justify-between w-full' : !stacked }">
-    <div :class="[stackedClass, sizeClass, textSizeClass]" v-if="label">
-      <label class="leading-5" :class="[lineClampClass]" :for="id">
+  <div
+    class="concrete__form-element"
+    :class="{ 'flex flex-row justify-between w-full': !stacked }"
+  >
+    <div
+      :class="[stackedClass, sizeClass, textSizeClass, labelOrderClass]"
+      v-if="label"
+    >
+      <label class="leading-4 whitespace-nowrap" :class="[lineClampClass]" :for="id">
         {{ label }}
       </label>
     </div>
-    <div :class="{ 'w-full' : expandInput }">
+    <div :class="{ 'w-full': expandInput }">
       <slot></slot>
-      <div :class="['text-xs', messageClass]" v-if="status.message">{{ status.message }}</div>
+      <div :class="['text-xs', messageClass]" v-if="status.message">
+        {{ status.message }}
+      </div>
     </div>
   </div>
 </template>
 
-
 <script setup>
-
 import { computed, provide } from 'vue';
 import { colorProp, useSizeProp } from '../../composables/props';
-import { useFormLabel, useSizeValue, useStackedValue, useInputStatus } from '../../composables/forms';
+import {
+  useFormLabel,
+  useSizeValue,
+  useStackedValue,
+  useInputStatus,
+} from '../../composables/forms';
 import { useInputClasses } from '../../composables/styles';
 
 const props = defineProps({
@@ -30,13 +41,10 @@ const props = defineProps({
   color: colorProp,
   size: useSizeProp(),
   noLabel: { type: Boolean },
+  labelOrder: { type: Number },
 });
 
-const {
-  textSizeClass,
-  heightClass,
-  disabledClass,
-} = useInputClasses(props);
+const { textSizeClass, heightClass, disabledClass } = useInputClasses(props);
 
 const label = useFormLabel(props);
 const size = useSizeValue(props.size);
@@ -44,15 +52,15 @@ const stacked = useStackedValue(props.stacked);
 const status = useInputStatus(props);
 
 provide('form-section', { stacked, size });
-provide('form-element', { size, color: props.color })
+provide('form-element', { size, color: props.color });
 
-const sizeCheck = (stacked) ? 'stacked' : size;
+const sizeCheck = stacked ? 'stacked' : size;
 const lineClampClass = {
   xs: 'line-clamp-1',
   sm: 'line-clamp-2',
   md: 'line-clamp-2',
   lg: 'line-clamp-2',
-  stacked: 'py-0.5 align-baseline'
+  stacked: 'py-0.5 align-baseline',
 }[sizeCheck];
 
 const sizeClass = stacked ? '' : heightClass;
@@ -69,6 +77,10 @@ const messageClass = computed(() => {
   }[status.value.color || 'default'];
 });
 
-const stackedClass = stacked ? 'mb-1 truncate' : 'basis-1/2 flex flex-col justify-center pr-8';
+const stackedClass = stacked
+  ? 'mb-1 truncate'
+  : 'flex basis-1/2 flex-col justify-center pr-6';
 
+const labelOrderClass =
+  props.labelOrder && `order-${props.labelOrder} !basis-auto`;
 </script>

--- a/src/components/FormSection/FormSection.vue
+++ b/src/components/FormSection/FormSection.vue
@@ -1,9 +1,13 @@
 <template>
   <div class="w-full concrete__form-section">
-
     <slot name="title">
-      <div class="flex justify-between w-full" :class="[underlineClass, inputColorClass, textSizeClass, heightClass]" >
-          <h2 v-if="title" class="font-bold">{{ title }}</h2>
+      <div
+        class="flex justify-between w-full mb-2"
+        :class="[underlineClass, inputColorClass, textSizeClass]"
+      >
+        <h2 v-if="title" class="text-lg text-sky-dark font-bold">
+          {{ title }}
+        </h2>
         <slot name="toolbar"></slot>
       </div>
     </slot>
@@ -15,12 +19,10 @@
 </template>
 
 <script setup>
-
 import { provide } from 'vue';
 import { colorProp, useSizeProp } from '../../composables/props';
 import { useSizeValue, useStackedValue } from '../../composables/forms';
-import { useInputClasses, useInputColorClassValue } from '../../composables/styles';
-
+import { useInputClasses } from '../../composables/styles';
 
 const props = defineProps({
   color: colorProp,
@@ -31,16 +33,11 @@ const props = defineProps({
   stacked: { type: Boolean },
 });
 
-const {
-  inputColorClass,
-  textSizeClass,
-  heightClass
-} = useInputClasses(props);
+const { inputColorClass, textSizeClass } = useInputClasses(props);
 
 const size = useSizeValue(props.size);
 const stacked = useStackedValue(props.stacked);
-provide('form-section',  { stacked, size });
+provide('form-section', { stacked, size });
 
-const underlineClass = (props.underline) ? 'border-b' : '';
-
+const underlineClass = props.underline ? 'border-b' : '';
 </script>

--- a/src/components/RadioGroup/RadioGroup.vue
+++ b/src/components/RadioGroup/RadioGroup.vue
@@ -41,7 +41,7 @@
               :class="[
                 heightClass,
                 svgColour,
-                reverseLabelOrder ? 'order-1' : '',
+                reverseLabels ? 'order-1' : '',
               ]"
               class="self-center"
               viewBox="0 0 20 20"
@@ -88,7 +88,7 @@ const props = defineProps({
   transparent: { type: Boolean, default: false },
   columns: { type: Number, default: 0 },
   onChange: { type: Function, default: null },
-  reverseLabelOrder: { type: Boolean, default: false },
+  reverseLabels: { type: Boolean, default: false },
 });
 
 const value = computed({
@@ -130,7 +130,7 @@ const svgColour = computed(() => {
 });
 
 const labelClasses = computed(() => {
-  if (!props.reverseLabelOrder) return;
+  if (!props.reverseLabels) return;
   return 'order-2 !ml-0 mr-2';
 });
 </script>

--- a/src/components/RadioGroup/RadioGroup.vue
+++ b/src/components/RadioGroup/RadioGroup.vue
@@ -2,47 +2,83 @@
   <component
     class="relative"
     :is="wrap ? CFormElement : CFragment"
-    v-bind="{ id, label, size, color, labelFormatter, message, stacked, noLabel }"
+    v-bind="{
+      id,
+      label,
+      size,
+      color,
+      labelFormatter,
+      message,
+      stacked,
+      noLabel,
+    }"
   >
-  <div class="flex" :class="[ textSizeClass, disabledClass]">
-    <RadioGroup 
-    class="concrete__radiogroup"
-    :class="layoutClass"
-    v-model="value" 
-    ref="el"
-    :disabled='disabled'
+    <div
+      class="flex bg-steel-lightest p-0.5 w-full border border-steel"
+      :class="[textSizeClass, disabledClass]"
     >
-      <RadioGroupOption v-for="option in options" :key="option" :value="option" v-slot="{ checked }">
-        <div class="flex cursor-pointer" >
-          <span class="ml-2 self-center grow text-right" :class="inputColorClass"> {{ props.formatter ? props.formatter(option) : option }}</span>
-            <svg :class="[heightClass,svgColour]" class="self-center" viewBox="0 0 20 20" >
+      <RadioGroup
+        class="concrete__radiogroup"
+        v-model="value"
+        ref="el"
+        :disabled="disabled"
+        :class="layoutClass"
+      >
+        <RadioGroupOption
+          v-for="option in options"
+          :key="option"
+          :value="option"
+          v-slot="{ checked }"
+        >
+          <div class="flex cursor-pointer mr-4">
+            <span
+              class="ml-2 self-center grow text-right"
+              :class="[inputColorClass, labelClasses]"
+            >
+              {{ props.formatter ? props.formatter(option) : option }}</span
+            >
+            <svg
+              :class="[
+                heightClass,
+                svgColour,
+                reverseLabelOrder ? 'order-1' : '',
+              ]"
+              class="self-center"
+              viewBox="0 0 20 20"
+            >
               <circle cx="10" cy="10" r="5" stroke-width="0.75" fill="none" />
               <transition enter-from-class="scale-0" leave-to-class="scale-0">
-                <circle class="transition origin-center" cx="10" cy="10" r="3.5" stroke="none" v-if="checked"  />
+                <circle
+                  class="transition origin-center"
+                  cx="10"
+                  cy="10"
+                  r="3.5"
+                  stroke="none"
+                  v-if="checked"
+                />
               </transition>
             </svg>
-        </div>
-      </RadioGroupOption>
-    </RadioGroup>
-  </div>
+          </div>
+        </RadioGroupOption>
+      </RadioGroup>
+    </div>
   </component>
 </template>
 
 <script setup>
-import { RadioGroup,  RadioGroupOption } from "@headlessui/vue";
+import { RadioGroup, RadioGroupOption } from '@headlessui/vue';
 import CFormElement from '../FormElement/FormElement.vue';
 import CFragment from '../Fragment/Fragment.vue';
-import { computed, ref } from "vue";
+import { computed, ref } from 'vue';
 import { formElementProps } from '../../composables/props';
 import { useInputClasses } from '../../composables/styles';
 import {
   useNoWrapValue,
   useInputValue,
   useRegisterInput,
-  useStackedValue
+  useStackedValue,
 } from '../../composables/forms.js';
 import { useEventHandler } from '../../composables/events.js';
-
 
 const props = defineProps({
   ...formElementProps,
@@ -50,8 +86,9 @@ const props = defineProps({
   options: { type: Array },
   formatter: { type: Function, default: null },
   transparent: { type: Boolean, default: false },
-  columns: {type:Number, default:0},
+  columns: { type: Number, default: 0 },
   onChange: { type: Function, default: null },
+  reverseLabelOrder: { type: Boolean, default: false },
 });
 
 const value = computed({
@@ -77,22 +114,23 @@ useRegisterInput(props, el);
 const stacked = useStackedValue(props.stacked);
 const wrap = !useNoWrapValue(props);
 
-const {
-  inputColorClass,
-  disabledClass,
-  textSizeClass,
-  heightClass,
-} = useInputClasses(props);
+const { inputColorClass, disabledClass, textSizeClass, heightClass } =
+  useInputClasses(props);
 
 const layoutClass = computed(() => {
   if (props.columns > 0) return `grid grid-flow-row grid-cols-${props.columns}`;
 
   return 'flex flex-wrap justify-end';
-})
+});
 
 const svgColour = computed(() => {
-    return props.color? 
-    "stroke-"+ props.color + " fill-"+ props.color:
-    "stroke-black fill-black";
-})
+  return props.color
+    ? 'stroke-' + props.color + ' fill-' + props.color
+    : 'stroke-black fill-black';
+});
+
+const labelClasses = computed(() => {
+  if (!props.reverseLabelOrder) return;
+  return 'order-2 !ml-0 mr-2';
+});
 </script>

--- a/src/components/Table/Table.vue
+++ b/src/components/Table/Table.vue
@@ -1,25 +1,30 @@
 <template>
-  <div class="flex flex-col">
-    <table class="table-fixed w-full">
-
+  <div class="flex flex-col w-full overflow-x-auto">
+    <table class="table-auto" :class="tableClass">
       <tr class="text-left border-b text-xs text-gray-600">
-        <th v-if="$slots.prepend" :class="prependClass"/>
-        <th v-for="col in columns" :key="col.id" :class="headerClass || 'pb-3 pl-1'">
+        <th v-if="$slots.prepend" :class="prependClass" />
+        <th
+          v-for="col in columns"
+          :key="col.id"
+          :class="headerClass || 'pb-3 pl-1'"
+        >
           <span
             :class="{ 'cursor-pointer': col.sortable }"
             @click="() => col.sortable && toggleSort(col.id)"
           >
             <slot :name="`${col.id}.header`">
-              <span :class="col.label || 'uppercase'"> {{ col.label || startCase(col.id) }} </span>
+              <span :class="col.label || 'uppercase'">
+                {{ col.label || startCase(col.id) }}
+              </span>
             </slot>
           </span>
           <span v-if="localSort[col.id] === 'asc'"> &#8593; </span>
           <span v-else-if="localSort[col.id] === 'desc'"> &#8595; </span>
           <span v-else-if="col.sortable" class="text-gray-400"> &#8645; </span>
         </th>
-        <th v-if="attrs.onEdit || attrs.onAdd" class="w-12"/>
-        <th v-if="attrs.onEdit || attrs.onAdd || attrs.onDelete" class="w-12"/>
-        <th v-if="$slots.append" :class="appendClass"/>
+        <th v-if="attrs.onEdit || attrs.onAdd" class="w-12" />
+        <th v-if="attrs.onEdit || attrs.onAdd || attrs.onDelete" class="w-12" />
+        <th v-if="$slots.append" :class="appendClass" />
       </tr>
 
       <tr
@@ -28,15 +33,19 @@
         :class="[
           attrs.onClick && editingRow?._index !== i && 'cursor-pointer',
           editingRow?._index === i && 'bg-gray-100',
-          rowClass || 'border-b'
+          rowClass || 'border-b',
         ]"
         @click="editingRow?._index !== i && emit('click', row)"
       >
         <td v-if="$slots.prepend">
-          <slot name="prepend" v-bind="row"/>
+          <slot name="prepend" v-bind="row" />
         </td>
 
-        <td v-for="(col, j) in columns" :class="cellClass || 'py-3 px-2'" :key="`col${j}`">
+        <td
+          v-for="(col, j) in columns"
+          :class="cellClass || 'py-3 px-2'"
+          :key="`col${j}`"
+        >
           <slot
             :name="col.id"
             :value="editingRow?._index === i ? editingRow[col.id] : row[col.id]"
@@ -51,31 +60,31 @@
 
         <td v-if="editingRow?._index === i">
           <span class="cursor-pointer" @click.stop="saveEdit">
-            <c-icon type="save" size="sm"/>
+            <c-icon type="save" size="sm" />
           </span>
         </td>
         <td v-else-if="attrs.onEdit && editingRow?.index !== i">
           <span class="cursor-pointer" @click.stop="beginEditingRow(row, i)">
-            <c-icon type="edit" size="sm"/>
+            <c-icon type="edit" size="sm" />
           </span>
         </td>
 
         <td v-if="editingRow?._index === i">
           <span class="cursor-pointer" @click.stop="editingRow = null">
-            <c-icon type="cancel" size="sm"/>
+            <c-icon type="cancel" size="sm" />
           </span>
         </td>
 
         <td v-else-if="attrs.onDelete">
           <div class="flex items-center">
             <span class="cursor-pointer" @click.stop="emit('delete', row)">
-              <c-icon type="trash" size="sm"/>
+              <c-icon type="trash" size="sm" />
             </span>
           </div>
         </td>
 
         <td v-if="$slots.append">
-          <slot name="append" v-bind="row"/>
+          <slot name="append" v-bind="row" />
         </td>
       </tr>
 
@@ -94,12 +103,12 @@
         </td>
         <td>
           <span @click="saveAdd" class="cursor-pointer">
-            <c-icon type="save" size="sm"/>
+            <c-icon type="save" size="sm" />
           </span>
         </td>
         <td>
           <span @click="addingRow = null" class="cursor-pointer">
-            <c-icon type="cancel" size="sm"/>
+            <c-icon type="cancel" size="sm" />
           </span>
         </td>
       </tr>
@@ -144,6 +153,7 @@ const props = defineProps({
   rowClass: String,
   cellClass: String,
   headerClass: String,
+  tableClass: String,
 });
 
 const emit = defineEmits(['change']);
@@ -180,18 +190,23 @@ function saveAdd() {
 }
 
 const _columns = computed(() => {
-  return props.columns.map(col => typeof col === 'string' ? ({ id: col }) : col)
-})
+  return props.columns.map((col) =>
+    typeof col === 'string' ? { id: col } : col
+  );
+});
 
 const localSort = ref(
-  props.sort
-  || _columns.value.reduce((acc, col) => ({ ...acc, [col.id]: col.defaultSort }), {})
+  props.sort ||
+    _columns.value.reduce(
+      (acc, col) => ({ ...acc, [col.id]: col.defaultSort }),
+      {}
+    )
 );
 
 watch(
   () => props.sort,
-  () => localSort.value = props.sort
-)
+  () => (localSort.value = props.sort)
+);
 
 function toggleSort(colId) {
   const currentSort = localSort.value[colId];
@@ -208,8 +223,8 @@ function toggleSort(colId) {
 const localPageNumber = ref(props.pageNumber || 1);
 watch(
   () => props.pageNumber,
-  () => localPageNumber.value = props.pageNumber
-)
+  () => (localPageNumber.value = props.pageNumber)
+);
 
 function selectPageNumber(newPageNumber) {
   localPageNumber.value = newPageNumber;
@@ -218,7 +233,7 @@ function selectPageNumber(newPageNumber) {
 
 const _rows = computed(() => {
   if (props.server) {
-    return props.rows
+    return props.rows;
   }
   const sortColIds = _columns.value
     .filter((col) => localSort.value[col.id])
@@ -245,5 +260,3 @@ watch(
   () => (errors.value = {})
 );
 </script>
-
-<style scoped></style>


### PR DESCRIPTION
To better support a reported troublesome resolution of 1366px several elements have been revised. In general, the layout has been improved to allow more space and become responsive when needed. The target snap point is "2xl" - 1560px IIRC.

Files changed, any why:

**Checkbox.vue & RadioGroup.vue** - these now accept a "labelOrder" prop that places the control input before the label, rather than after it. If the prop is omitted, the layout should render as before. 

**Table.vue** - this now accepts a "tableClass" prop allowing arbitrary classes to be passed in. For column shoes > loads, this solves the issue whereby the table is far too narrow to show its content. Scrollbars and overflow in general have been addressed also.

**FormSection.vue && FormElement.vue** - general styling improvements such as removing the grey background. Screen real estate is now much improved.

Misc UI improvements such as alignment have also been tweaked. 

A corresponding branch in column shoes named "TSCSC-604-national-annex-dropdown-list" (actually a sub task of the parent,  601) uses these new enhancements. 

Here is the new layout
![1](https://user-images.githubusercontent.com/55240533/228809212-76b38b96-a5ea-4edb-822b-86aa2c79d2f0.png)
