### PR TITLE
feat: optionally hide numeric spinners

### DIFF
--- a/src/components/FormSection/FormSection.vue
+++ b/src/components/FormSection/FormSection.vue
@@ -5,7 +5,7 @@
         class="flex justify-between w-full mb-2"
         :class="[underlineClass, inputColorClass, textSizeClass]"
       >
-        <h2 v-if="title" class="text-lg text-sky-dark font-bold">
+        <h2 v-if="title" class="text-sm text-sky-dark font-bold">
           {{ title }}
         </h2>
         <slot name="toolbar"></slot>

--- a/src/components/FormSection/FormSection.vue
+++ b/src/components/FormSection/FormSection.vue
@@ -5,9 +5,9 @@
         class="flex justify-between w-full mb-2"
         :class="[underlineClass, inputColorClass, textSizeClass]"
       >
-        <h2 v-if="title" class="text-sm text-sky-dark font-bold">
+        <h4 v-if="title" class="text-sm text-sky-dark font-bold">
           {{ title }}
-        </h2>
+        </h4>
         <slot name="toolbar"></slot>
       </div>
     </slot>


### PR DESCRIPTION
Add prop to numeric input to hide spinner. This is done via CSS "appearance" as well as margin tweaks.

Also reduced font size of section headers to be slightly smaller.