### PR TITLE
fix: fix overflow issue on smaller (v) screens

### DIFF
--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -25,7 +25,7 @@
 
     <DisclosurePanel static>
       <div
-        class="overflow-hidden"
+        class="overflow-x-hidden overflow-y-auto"
         :class="transition && transitionClass"
         :style="{ height }"
       >


### PR DESCRIPTION
Fix overflow issue. This needs overflow-y-auto to prevent lopping off select lists etc.