### PR TITLE
fix: revised and reactivated resizable

### DIFF
--- a/src/components/Resizable/Pane.vue
+++ b/src/components/Resizable/Pane.vue
@@ -9,7 +9,6 @@ import { inject, ref, onMounted } from 'vue';
 
 const props = defineProps({
   min: { type: Number, default: null },
-  primary: { type: Boolean, default: false },
 });
 
 const paneRef = ref(null);
@@ -19,7 +18,6 @@ onMounted(() => {
   resizablePane.registerPane({
     el: paneRef.value,
     min: props.min,
-    primary: props.primary,
   });
 });
 </script>

--- a/src/components/Resizable/Pane.vue
+++ b/src/components/Resizable/Pane.vue
@@ -9,6 +9,7 @@ import { inject, ref, onMounted } from 'vue';
 
 const props = defineProps({
   min: { type: Number, default: null },
+  primary: { type: Boolean, default: false },
 });
 
 const paneRef = ref(null);
@@ -18,6 +19,7 @@ onMounted(() => {
   resizablePane.registerPane({
     el: paneRef.value,
     min: props.min,
+    primary: props.primary,
   });
 });
 </script>

--- a/src/components/Resizable/Pane.vue
+++ b/src/components/Resizable/Pane.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="concrete__pane" ref="paneRef">
+  <div class="concrete__pane flex-1" ref="paneRef">
     <slot />
   </div>
 </template>

--- a/src/components/Resizable/Pane.vue
+++ b/src/components/Resizable/Pane.vue
@@ -8,7 +8,7 @@
 import { inject, ref, onMounted } from 'vue';
 
 const props = defineProps({
-  min: { type: Number, default: null },
+  min: { type: Number, default: null, validator: (prop) => prop <= 90 },
   primary: { type: Boolean, default: false },
 });
 

--- a/src/components/Resizable/Pane.vue
+++ b/src/components/Resizable/Pane.vue
@@ -7,10 +7,9 @@
 <script setup>
 import { inject, ref, onMounted } from 'vue';
 
-
 const props = defineProps({
-  max: { type: Number, default: null },
   min: { type: Number, default: null },
+  primary: { type: Boolean, default: false },
 });
 
 const paneRef = ref(null);
@@ -20,7 +19,7 @@ onMounted(() => {
   resizablePane.registerPane({
     el: paneRef.value,
     min: props.min,
-    max: props.max,
+    primary: props.primary,
   });
 });
 </script>

--- a/src/components/Resizable/Resizable.vue
+++ b/src/components/Resizable/Resizable.vue
@@ -1,31 +1,35 @@
 <template>
-  <div ref="containerRef" @mousemove="drag" @mouseup="endDrag" draggable="false" class="concrete__resizable relative" :class="{ 'cursor-col-resize' : dragging }" >
-    <slot/>
-    
+  <!-- <div ref="containerRef" draggable="false" class="concrete__resizable relative" :class="{ 'cursor-col-resize' : dragging }" >  -->
+  <div
+    ref="containerRef"
+    class="concrete__resizable relative"
+    @mousemove="drag"
+    @mouseup="endDrag"
+  >
+    <slot />
     <div
       class="separator absolute"
       :class="splitterClass"
-      :style="splitterStyle"
       @mousedown="startDrag"
       @mousemove="drag"
       @mouseup="endDrag"
       @touchstart="startDrag"
       @touchmove="drag"
       @touchend="endDrag"
-      
+      ref="splitter"
     ></div>
   </div>
 </template>
 
 <style scoped lang="scss">
 .separator {
-    /* Prevent the browser's built-in drag from interfering */
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    cursor: col-resize;
-    z-index: 69;
-    height: 100%;
+  /* Prevent the browser's built-in drag from interfering */
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  cursor: col-resize;
+  z-index: 69;
+  height: 100%;
 }
 
 .seperator-img {
@@ -36,7 +40,7 @@
 </style>
 
 <script setup>
-import { computed, ref, provide, onMounted  } from 'vue';
+import { computed, ref, provide, onMounted } from 'vue';
 
 const props = defineProps({
   splitter: {
@@ -46,129 +50,107 @@ const props = defineProps({
   },
 });
 
+const emit = defineEmits(['resize']);
+
+const splitter = ref(null);
+const panes = ref([]);
+const containerRef = ref(null);
+let primaryPaneIndex;
+let currDrag;
+let dragging = false;
+
+const leftPane = computed(() => panes.value[0]);
+const rightPane = computed(() => panes.value[1]);
+
 const splitterClass = computed(() => {
   return {
-    'thin': 'w-1 bg-gray-300',
-    'thick': 'seperator-img w-3 bg-gray-300',
-    'default': 'w-3 bg-transparent hover:bg-gray-300 hover:opacity-40',
+    thin: 'w-1 bg-gray-300',
+    thick: 'seperator-img w-3 bg-gray-300',
+    default: 'w-3 bg-transparent hover:bg-gray-300 hover:opacity-40',
   }[props.splitter];
 });
 
-const splitterStyle = computed(() => {
-  const pos = panes.value[0]?.size;
-  const width = {
-    'thin': 4,
-    'thick': 12,
-    'default': 12,
+const splitterWidth = computed(() => {
+  return {
+    thin: 2,
+    thick: 6,
+    default: 6,
   }[props.splitter];
-  return`left: ${(pos-(width/2))}px`;
-})
-
-const emit = defineEmits(['resize']);
-
-let dragging = false;
-const activeProp = 'x';
+});
 
 const startDrag = () => {
   dragging = true;
-}
+};
+
 const endDrag = () => {
   dragging = false;
-}
+  if (primaryPaneIndex === 0) {
+    leftPane.value.el.style.width = `${currDrag}px`;
+  } else {
+    rightPane.value.el.style.width = `${
+      containerRef.value.getBoundingClientRect().width - currDrag
+    }px`;
+  }
+};
 
 const drag = (e) => {
-  if(dragging) {
-    const currDrag = getCurrentMouseDrag(e)[activeProp];
-    resizePanes(currDrag);
+  if (dragging) {
+    currDrag = getCurrentMouseDrag(e).x;
+
+    if (primaryPaneIndex === 0) {
+      splitter.value.style.left =
+        currDrag < panes.value[primaryPaneIndex].min
+          ? `${panes.value[primaryPaneIndex].min}px`
+          : `${currDrag}px`;
+      return;
+    }
+
+    splitter.value.style.right =
+      currDrag >
+      containerRef.value.getBoundingClientRect().width -
+        panes.value[primaryPaneIndex].min
+        ? `${panes.value[primaryPaneIndex].min}px`
+        : `${currDrag}px`;
   }
 };
-
-const resizeObserver = new ResizeObserver(() => {
-
-  panes.value[0].el.setAttribute('style', '');
-  panes.value[1].el.setAttribute('style', '');
-  resizePanes(dragPos);
-});
-
-const panes = ref([]);
-const containerRef = ref(null);
-let dragPos = null;
 
 onMounted(() => {
-  resizePanes();
-  resizeObserver.observe(containerRef.value);
-})
+  primaryPaneIndex = panes.value.findIndex((p) => p.primary) ?? 0;
 
-const resizePanes = (currDrag) => {
-  const elementWidth = containerRef.value?.offsetWidth;
-  if(!elementWidth) return;
-  if(elementWidth > panes.value.reduce((a, b) => a+b.max )) {
-    // too much space for max values;
-    console.error('resizable: too much space for pane max values')
-  } else if(elementWidth < panes.value.reduce((a, b) => a+b.min )) {
-    // not enough space for min values;
-    console.error('resizable: not enough space for pane min values')
-  } else if(panes.value[0] && panes.value[1]){
-    
-    let newDragPos = null;
-    if(currDrag) {
-      if(panes.value[0]?.max && (currDrag > panes.value[0].max)) {
-        newDragPos = panes.value[0].max;
-      } else if(panes.value[1]?.max && ((elementWidth-currDrag) > panes.value[1].max)) {
-        newDragPos = elementWidth-panes.value[1].max;
-      } else if(panes.value[0]?.min && (currDrag < panes.value[0].min)) {
-        newDragPos = panes.value[0].min;
-      } else if(panes.value[1]?.min && ((elementWidth-currDrag) < panes.value[1].min)) {
-        newDragPos = elementWidth-panes.value[1].min;
-      } else {
-        newDragPos = currDrag;
-      }
-    } else {
-      const distributedWidth = elementWidth / panes.value.length;
-      if(panes.value[0]?.max && (distributedWidth > panes.value[0].max)) {
-        newDragPos = panes.value[0].max;
-      } else if(panes.value[1]?.max && (distributedWidth > panes.value[1].max)) {
-        newDragPos = elementWidth-panes.value[1].max;
-      } else if(panes.value[0]?.min && (distributedWidth < panes.value[0].min)) {
-        newDragPos = panes.value[0].min;
-      } else if(panes.value[1]?.min && (distributedWidth < panes.value[1].min)) {
-        newDragPos = elementWidth-panes.value[1].min;
-      } else {
-        newDragPos = distributedWidth;
-      }
-    }
-    updatePane(0, newDragPos)
-    updatePane(1, elementWidth-newDragPos)
-    dragPos = newDragPos;
-    emit('resize', [panes.value[0].size, panes.value[1].size])
+  if (panes.value[primaryPaneIndex].min)
+    panes.value[
+      primaryPaneIndex
+    ].el.style.minWidth = `${panes.value[primaryPaneIndex].min}px`;
+
+  if (primaryPaneIndex === 0) {
+    leftPane.value.el.classList.remove('flex-1');
+    rightPane.value.el.classList.add('flex-1');
+    splitter.value.style.left = `${splitterElementLeftPosition.value}px`;
+    return;
   }
-};
 
-const updatePane = (index, value) => {
-  panes.value[index].size = value;
-  panes.value[index].el.setAttribute('style', `width: ${panes.value[index].size}px`);
-}
+  rightPane.value.el.classList.remove('flex-1');
+  leftPane.value.el.classList.add('flex-1');
+  splitter.value.style.left = `${splitterElementLeftPosition.value}px`;
+});
+
+const splitterElementLeftPosition = computed(
+  () => leftPane.value.el.getBoundingClientRect().width - splitterWidth.value
+);
 
 const getCurrentMouseDrag = (e) => {
-  const rect = containerRef.value.getBoundingClientRect()
-  const { clientX, clientY } = ('ontouchstart' in window && e.touches) ? e.touches[0] : e
-
+  const rect = containerRef.value.getBoundingClientRect();
+  const { clientX } = 'ontouchstart' in window && e.touches ? e.touches[0] : e;
   return {
     x: clientX - rect.left,
-    y: clientY - rect.top
-  }
+  };
 };
 
-
-const registerPane  = (pane)  => {
-  panes.value.push(pane);  
-  resizePanes();  
+const registerPane = (pane) => {
+  panes.value.push(pane);
 };
 
-provide('resizable-pane',  {
+provide('resizable-pane', {
   registerPane,
-})
-
-
-
+});
 </script>

--- a/src/components/Resizable/Resizable.vue
+++ b/src/components/Resizable/Resizable.vue
@@ -170,7 +170,7 @@ const validateMinProps = () => {
       'prop "min" values provided breach 100%. Both now set to 50%.'
     );
   } else {
-    const leftMin = panes.value[0].min || 50;
+    const leftMin = panes.value[0].min || 10; //90% is maximum allowed so this will allocate a sensible default
     const rightMin = panes.value[1].min || 10;
     leftMinWidth = containerWidth * (leftMin / 100);
     rightMinWidth = containerWidth * (rightMin / 100);

--- a/src/components/Resizable/Resizable.vue
+++ b/src/components/Resizable/Resizable.vue
@@ -153,13 +153,28 @@ const setRightPrimary = () => {
 
 const initialSetup = () => {
   if (primaryPaneIndex !== 0) leftIsPrimary = false;
-
-  leftMinWidth = panes.value[0].min || 200;
-  rightMinWidth = panes.value[1].min || 200;
-
+  validateMinProps();
   splitter.value.style.left = `${
     leftPane.value.el.getBoundingClientRect().width - splitterWidth.value
   }px`;
+};
+
+const validateMinProps = () => {
+  const containerWidth = containerClientRect.value.width;
+
+  //calculate pixels from percentages
+  if (panes.value[0].min + panes.value[1].min > 100) {
+    leftMinWidth = containerWidth / 2;
+    rightMinWidth = containerWidth / 2;
+    console.warn(
+      'prop "min" values provided breach 100%. Both now set to 50%.'
+    );
+  } else {
+    const leftMin = panes.value[0].min || 50;
+    const rightMin = panes.value[1].min || 10;
+    leftMinWidth = containerWidth * (leftMin / 100);
+    rightMinWidth = containerWidth * (rightMin / 100);
+  }
 };
 
 onMounted(() => {
@@ -170,6 +185,7 @@ onMounted(() => {
       resizeObserver.observe(p);
     });
 
+  validateMinProps();
   initialSetup();
   handleResize();
 

--- a/src/components/Resizable/Resizable.vue
+++ b/src/components/Resizable/Resizable.vue
@@ -56,7 +56,6 @@ const splitter = ref(null);
 const panes = ref([]);
 const containerRef = ref(null);
 let primaryPaneIndex;
-let secondaryPaneIndex;
 let currDrag;
 let dragging = false;
 
@@ -120,10 +119,8 @@ onMounted(() => {
   }
 
   primaryPaneIndex = panes.value.findIndex((p) => p.primary) ?? 0;
-  secondaryPaneIndex = panes.value.findIndex((p) => !p.primary) ?? 1;
 
   if (primaryPaneIndex < 0) primaryPaneIndex = 0; //handle no primary set
-  if (secondaryPaneIndex < 0) primaryPaneIndex = 1;
 
   if (panes.value[primaryPaneIndex].min)
     panes.value[primaryPaneIndex].el.style.minWidth = getPrimaryPaneWidth.value;

--- a/src/components/Resizable/Resizable.vue
+++ b/src/components/Resizable/Resizable.vue
@@ -91,6 +91,7 @@ const startDrag = () => {
 const endDrag = () => {
   dragging = false;
   handleResize();
+  window.dispatchEvent(new Event('resize'));
 };
 
 const drag = (e) => {

--- a/src/components/Resizable/__stories__/Resizable.stories.mdx
+++ b/src/components/Resizable/__stories__/Resizable.stories.mdx
@@ -26,10 +26,10 @@ export const componentTemplate = (args) => ({
   },
   methods: {},
   template: `<CResizable v-bind="args" class="my-8 bg-sky-light h-96 flex ">
-  <CPane class="border-r-2 border-indigo" :min="350">
+  <CPane class="border-r-2 border-indigo" primary :min="35">
     <div class="text-2xl bg-success-lightest text-success font-bold text-center h-96 py-32">1</div>
   </CPane>
-  <CPane class="" :min="200">
+  <CPane class="" :min="20">
     <div class="text-2xl bg-danger-lightest text-danger font-bold text-center h-96 py-32">2</div>
   </CPane>
 </CResizable>

--- a/src/index.js
+++ b/src/index.js
@@ -124,4 +124,6 @@ export {
   CToolGroup,
   CViewport,
   CViewportContainer,
+  CResizable,
+  CPane,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ import CSvg2dViewport from './components/Svg2dViewport/Svg2dViewport.vue';
 import CDraggablePath from './components/DraggablePath/DraggablePath.vue';
 import CDraggablePoint from './components/DraggablePoint/DraggablePoint.vue';
 import { CTable, CInputCell } from './components/Table';
+import { CResizable, CPane } from './components/Resizable';
 
 import { defaultOptions } from './composables/concrete';
 
@@ -63,6 +64,8 @@ const allComponents = {
   CToolGroup,
   CViewport,
   CViewportContainer,
+  CResizable,
+  CPane,
 };
 
 const install = (app, userOptions = {}) => {


### PR DESCRIPTION
Reactivated the dormant Resizable component. This is implemented in column shoes branch with the same name. This works differently to before and utilises the flex layout rather than fixed pixel sizes - although some fixed sizing is still needed.

Changes:

- No longer accepts max prop
- Accepts "primary" prop to set which pane (left or right) should have its "min" prop applied - this is due the the flex layout whereby we want free space filled.
- Flickering (perpetual resize loop) issues resolved
- Cases with no primary or no min set are handled
