### PR TITLE
fix: add state to accordions

### DIFF
--- a/src/components/Table/Table.vue
+++ b/src/components/Table/Table.vue
@@ -156,7 +156,7 @@ const props = defineProps({
   tableClass: String,
 });
 
-const emit = defineEmits(['change']);
+const emit = defineEmits(['change', 'click']);
 const attrs = useAttrs();
 
 const editingRow = ref(null);

--- a/src/composables/concrete.js
+++ b/src/composables/concrete.js
@@ -1,4 +1,4 @@
-import { inject } from 'vue';
+import { inject, ref } from 'vue';
 
 export const defaultOptions = {
   size: 'md',
@@ -9,6 +9,8 @@ export const defaultOptions = {
   inputIdToValue: null,
   wrapFormInputs: true,
 }
+
+export const accordionState = ref(null);
 
 export const useConcrete = () => {
   return inject('concrete', defaultOptions);


### PR DESCRIPTION
Added a stateful object to concrete.js to contain an application's accordion open/closed states.

Fixed Table.vue emit warning bug by adding emitter.