### PR TITLE
Fix/add state to accordions

### DIFF
--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -1,50 +1,58 @@
 <template>
-  <Disclosure
-    as="div"
-    v-slot="{ open }"
-    class="concrete__accordion"
-    :class="textClass"
-    :defaultOpen="defaultOpen"
-  >
-    <DisclosureButton class="w-full text-left" @click="onClick(!open)">
-      <div v-if="title" class="flex items-center font-bold">
-        <TriangleIcon
-          :class="[
-            iconClass,
-            transitionClass,
-            open ? 'rotate-180' : 'rotate-90',
-          ]"
-          class="flex-none mr-2"
-        />
-        <slot name="customTitle" v-if="$slots.customTitle" />
-        <span v-else :class="titleClass">{{ title }}</span>
-      </div>
-
-      <slot v-else name="title" :open="open" />
-    </DisclosureButton>
-
-    <DisclosurePanel static>
-      <div
-        class="overflow-x-hidden overflow-y-auto"
-        :class="transition && transitionClass"
-        :style="{ height }"
-      >
-        <div ref="content">
-          <slot :open="open" />
+  <div>
+    OPEN: {{ isOpen }}
+    <Disclosure
+      as="div"
+      v-slot="{ open }"
+      class="concrete__accordion"
+      :class="textClass"
+      :defaultOpen="isOpen"
+    >
+      <DisclosureButton class="w-full text-left" @click="onClick(!open)">
+        <div v-if="title" class="flex items-center font-bold">
+          <TriangleIcon
+            :class="[
+              iconClass,
+              transitionClass,
+              open ? 'rotate-180' : 'rotate-90',
+            ]"
+            class="flex-none mr-2"
+          />
+          <slot name="customTitle" v-if="$slots.customTitle" />
+          <span v-else :class="titleClass">{{ title }}</span>
         </div>
-      </div>
-    </DisclosurePanel>
-  </Disclosure>
+
+        <slot v-else name="title" :open="open" />
+      </DisclosureButton>
+
+      <DisclosurePanel static>
+        <div
+          class="overflow-x-hidden overflow-y-auto"
+          :class="transition && transitionClass"
+          :style="{ height }"
+        >
+          <div ref="content">
+            <slot :open="open" />
+          </div>
+        </div>
+      </DisclosurePanel>
+    </Disclosure>
+  </div>
 </template>
 
 <script setup>
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue';
 
-import { ref } from 'vue';
+import { ref, onMounted, inject } from 'vue';
 import TriangleIcon from '../Icon/icons/TriangleIcon.vue';
 import { useSizeProp } from '../../composables/props.js';
 import { useSizeValue } from '../../composables/forms.js';
 import { textSizeClassMap } from '../../composables/styles.js';
+
+const { accordionState } = inject('concrete', {});
+
+const isOpen = ref(false);
+const hasAccordionId = props.accordionId !== '';
 
 const props = defineProps({
   defaultOpen: { type: Boolean, default: false },
@@ -52,11 +60,12 @@ const props = defineProps({
   size: useSizeProp('lg'),
   title: String,
   titleClass: String,
+  accordionId: { type: String, required: false },
 });
 
 const emit = defineEmits(['opened', 'closed']);
 
-const initialHeight = props.defaultOpen ? 'auto' : 0;
+const initialHeight = isOpen.value ? 'auto' : 0;
 const height = ref(initialHeight);
 const content = ref(null);
 const TRANSITION_TIME = props.transition ? 400 : 0;
@@ -74,16 +83,33 @@ const iconClass = {
 }[size];
 
 const onClick = (open) => {
+  isOpen.value = open;
+  accordionState[props.accordionId] = isOpen.value;
+
   const contentHeight = content.value.getBoundingClientRect().height;
   height.value = contentHeight + 'px';
 
-  if (open) {
+  if (isOpen.value) {
     setTimeout(() => (height.value = 'auto'), TRANSITION_TIME);
+
     emit('opened');
   } else {
     setTimeout(() => (height.value = '0'));
     emit('closed');
   }
-    
+
+  console.warn(
+    'C',
+    accordionState[props.accordionId],
+    accordionState,
+    isOpen.value
+  );
 };
+
+if (hasAccordionId && !accordionState.hasOwnProperty(props.accordionId)) {
+  accordionState[props.accordionId] = props.defaultOpen;
+  isOpen.value = accordionState[props.accordionId];
+} else {
+  isOpen.value = props.defaultOpen;
+}
 </script>

--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -1,42 +1,40 @@
 <template>
-  <div>
-    {{ isOpen }}
-    <Disclosure
-      as="div"
-      v-slot="{ open: isOpen }"
-      class="concrete__accordion"
-      :class="textClass"
-    >
-      <DisclosureButton class="w-full text-left" @click="onClick()">
-        <div v-if="title" class="flex items-center font-bold">
-          <TriangleIcon
-            :class="[
-              iconClass,
-              transitionClass,
-              isOpen ? 'rotate-180' : 'rotate-90',
-            ]"
-            class="flex-none mr-2"
-          />
-          <slot name="customTitle" v-if="$slots.customTitle" />
-          <span v-else :class="titleClass">{{ title }}</span>
-        </div>
+  <Disclosure
+    as="div"
+    v-slot="{ open }"
+    class="concrete__accordion"
+    :class="textClass"
+    :defaultOpen="isOpen"
+  >
+    <DisclosureButton class="w-full text-left" @click="onClick()">
+      <div v-if="title" class="flex items-center font-bold">
+        <TriangleIcon
+          :class="[
+            iconClass,
+            transitionClass,
+            open ? 'rotate-180' : 'rotate-90',
+          ]"
+          class="flex-none mr-2"
+        />
+        <slot name="customTitle" v-if="$slots.customTitle" />
+        <span v-else :class="titleClass">{{ title }}</span>
+      </div>
 
-        <slot v-else name="title" :open="isOpen" />
-      </DisclosureButton>
+      <slot v-else name="title" :open="open" />
+    </DisclosureButton>
 
-      <DisclosurePanel static>
-        <div
-          class="overflow-x-hidden overflow-y-auto"
-          :class="transition && transitionClass"
-          :style="{ height }"
-        >
-          <div ref="content">
-            <slot :open="isOpen" />
-          </div>
+    <DisclosurePanel static>
+      <div
+        class="overflow-x-hidden overflow-y-auto"
+        :class="transition && transitionClass"
+        :style="{ height }"
+      >
+        <div ref="content">
+          <slot :open="open" />
         </div>
-      </DisclosurePanel>
-    </Disclosure>
-  </div>
+      </div>
+    </DisclosurePanel>
+  </Disclosure>
 </template>
 
 <script setup>
@@ -59,22 +57,11 @@ const props = defineProps({
   accordionId: { type: String, required: false },
 });
 
-let isOpen = ref(false);
-
-if (props.accordionId) {
-  if (accordionState.hasOwnProperty(props.accordionId)) {
-    isOpen.value = accordionState[props.accordionId];
-  } else {
-    accordionState[props.accordionId] = props.defaultOpen;
-    isOpen.value = props.defaultOpen;
-  }
-} else {
-  isOpen.value = props.defaultOpen;
-}
+let isOpen = accordionState[props.accordionId] ?? props.defaultOpen;
 
 const emit = defineEmits(['opened', 'closed']);
 
-const initialHeight = isOpen.value ? 'auto' : 0;
+const initialHeight = isOpen ? 'auto' : 0;
 const height = ref(initialHeight);
 const content = ref(null);
 const TRANSITION_TIME = props.transition ? 400 : 0;
@@ -92,8 +79,8 @@ const iconClass = {
 }[size];
 
 const onClick = () => {
-  isOpen.value = !isOpen.value;
-  accordionState[props.accordionId] = isOpen.value;
+  isOpen = !isOpen;
+  if (props.accordionId) accordionState[props.accordionId] = isOpen;
 
   const contentHeight = content.value.getBoundingClientRect().height;
   height.value = contentHeight + 'px';

--- a/src/components/Table/Table.vue
+++ b/src/components/Table/Table.vue
@@ -156,7 +156,7 @@ const props = defineProps({
   tableClass: String,
 });
 
-const emit = defineEmits(['change']);
+const emit = defineEmits(['change', 'click']);
 const attrs = useAttrs();
 
 const editingRow = ref(null);

--- a/src/composables/concrete.js
+++ b/src/composables/concrete.js
@@ -1,4 +1,4 @@
-import { inject } from 'vue';
+import { inject, ref } from 'vue';
 
 export const defaultOptions = {
   size: 'md',
@@ -9,6 +9,8 @@ export const defaultOptions = {
   inputIdToValue: null,
   wrapFormInputs: true,
 }
+
+export const accordionState = ref(null);
 
 export const useConcrete = () => {
   return inject('concrete', defaultOptions);


### PR DESCRIPTION
Second version of this. Sorry about that. The state for all accordions is now held within concrete, concrete.js file. Accordion instances are added to this state by passing an accordion-id prop.

Aside from passing this prop in, no work is needed in consuming apps at all. 

Styling has been updated.