### PR TITLE
Se 44 add transition to listbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw?
+.vs

--- a/src/App.vue
+++ b/src/App.vue
@@ -110,6 +110,15 @@
                   ></CListbox>
                 </div>
               </div>
+              <div>
+                <div class="bg-blue-300 p-1 mb-1">Autocomplete</div>
+                <CAutoComplete
+                  :options="['a', 'b']"
+                  size="sm"
+                  placeholder="Enter 'a' or 'b'"
+                >
+                </CAutoComplete>
+              </div>
             </div>
           </CFormSection>
           <CFormSection class="">

--- a/src/App.vue
+++ b/src/App.vue
@@ -113,7 +113,7 @@
               <div>
                 <div class="bg-blue-300 p-1 mb-1">Autocomplete</div>
                 <CAutoComplete
-                  :options="['a', 'b']"
+                  :options="['a', 'b', 'aa', 'bb', 'ab']"
                   size="sm"
                   placeholder="Enter 'a' or 'b'"
                 >

--- a/src/App.vue
+++ b/src/App.vue
@@ -96,6 +96,19 @@
                   </div>
                   <CListbox :options="[]"></CListbox>
                 </div>
+
+                <div>
+                  <div class="bg-blue-300 p-1 mb-1">Listbox with options</div>
+                  <CListbox
+                    :options="[
+                      'Option 1',
+                      'Option 2',
+                      'Option 3',
+                      'Option 4',
+                      'Option 5',
+                    ]"
+                  ></CListbox>
+                </div>
               </div>
             </div>
           </CFormSection>
@@ -104,34 +117,101 @@
               <div class="grid grid-cols-2 w-80 gap-x-8">
                 <CCheckbox v-model="checkValue" label="Default 1" />
                 <CCheckbox v-model="checkValue2" label="Default 2" />
-                <CCheckbox v-model="checkValue3" label="Default 3" :disabled="true" />
-                <CCheckbox v-model="checkValue4" label="Default 4" :disabled="true" />
+                <CCheckbox
+                  v-model="checkValue3"
+                  label="Default 3"
+                  :disabled="true"
+                />
+                <CCheckbox
+                  v-model="checkValue4"
+                  label="Default 4"
+                  :disabled="true"
+                />
               </div>
               <div class="grid grid-cols-2 w-80 gap-x-8">
-                <CCheckbox v-model="checkValue" label="Indigo 1" color="indigo" />
-                <CCheckbox v-model="checkValue2" label="Indigo 2" color="indigo" />
-                <CCheckbox v-model="checkValue3" label="Indigo 3" color="indigo" :disabled="true" />
-                <CCheckbox v-model="checkValue4" label="Indigo 4" color="indigo" :disabled="true" />
+                <CCheckbox
+                  v-model="checkValue"
+                  label="Indigo 1"
+                  color="indigo"
+                />
+                <CCheckbox
+                  v-model="checkValue2"
+                  label="Indigo 2"
+                  color="indigo"
+                />
+                <CCheckbox
+                  v-model="checkValue3"
+                  label="Indigo 3"
+                  color="indigo"
+                  :disabled="true"
+                />
+                <CCheckbox
+                  v-model="checkValue4"
+                  label="Indigo 4"
+                  color="indigo"
+                  :disabled="true"
+                />
               </div>
               <div class="grid grid-cols-2 w-80 gap-x-8">
                 <CCheckbox v-model="checkValue" label="Sky 1" color="sky" />
                 <CCheckbox v-model="checkValue2" label="Sky 2" color="sky" />
-                <CCheckbox v-model="checkValue3" label="Sky 3" color="sky" :disabled="true" />
-                <CCheckbox v-model="checkValue4" label="Sky 4" color="sky" :disabled="true" />
+                <CCheckbox
+                  v-model="checkValue3"
+                  label="Sky 3"
+                  color="sky"
+                  :disabled="true"
+                />
+                <CCheckbox
+                  v-model="checkValue4"
+                  label="Sky 4"
+                  color="sky"
+                  :disabled="true"
+                />
               </div>
               <div class="grid grid-cols-2 w-80 gap-x-8">
                 <CCheckbox v-model="checkValue" label="Steel 1" color="steel" />
-                <CCheckbox v-model="checkValue2" label="Steel 2" color="steel" />
-                <CCheckbox v-model="checkValue3" label="Steel 3" color="steel" :disabled="true" />
-                <CCheckbox v-model="checkValue4" label="Steel 4" color="steel" :disabled="true" />
+                <CCheckbox
+                  v-model="checkValue2"
+                  label="Steel 2"
+                  color="steel"
+                />
+                <CCheckbox
+                  v-model="checkValue3"
+                  label="Steel 3"
+                  color="steel"
+                  :disabled="true"
+                />
+                <CCheckbox
+                  v-model="checkValue4"
+                  label="Steel 4"
+                  color="steel"
+                  :disabled="true"
+                />
               </div>
               <div class="grid grid-cols-2 w-80 gap-x-8">
-                <CCheckbox v-model="checkValue" label="Transparent 1" :transparent="true" />
-                <CCheckbox v-model="checkValue2" label="Transparent 2" :transparent="true" />
-                <CCheckbox v-model="checkValue3" label="Transparent 3" :transparent="true" :disabled="true" />
-                <CCheckbox v-model="checkValue4" label="Transparent 4" :transparent="true" :disabled="true" />
+                <CCheckbox
+                  v-model="checkValue"
+                  label="Transparent 1"
+                  :transparent="true"
+                />
+                <CCheckbox
+                  v-model="checkValue2"
+                  label="Transparent 2"
+                  :transparent="true"
+                />
+                <CCheckbox
+                  v-model="checkValue3"
+                  label="Transparent 3"
+                  :transparent="true"
+                  :disabled="true"
+                />
+                <CCheckbox
+                  v-model="checkValue4"
+                  label="Transparent 4"
+                  :transparent="true"
+                  :disabled="true"
+                />
               </div>
-
             </div>
           </CFormSection>
         </div>
@@ -146,7 +226,11 @@
               :options="[{ label: 'Cross Section', value: 'top' }]"
             >
               <template v-slot:tools>
-                <CTool name="Zoom to Fit" tool-id="zoom-to-fit" :stateful="false">
+                <CTool
+                  name="Zoom to Fit"
+                  tool-id="zoom-to-fit"
+                  :stateful="false"
+                >
                   <XMarkIcon />
                 </CTool>
               </template>
@@ -158,13 +242,16 @@
               :options="[{ label: 'Side View', value: 'bottom' }]"
             >
               <template v-slot:tools>
-                <CTool name="Zoom to Fit" tool-id="zoom-to-fit" :stateful="false">
+                <CTool
+                  name="Zoom to Fit"
+                  tool-id="zoom-to-fit"
+                  :stateful="false"
+                >
                   <XMarkIcon />
                 </CTool>
               </template>
               <div class="h-64 w-full bg-red-300"></div>
             </CViewport>
-
           </CViewportContainer>
         </div>
       </div>

--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -89,11 +89,14 @@ const onClick = () => {
 
   if (isOpen) {
     styles.height = height.value;
-    setTimeout(() => (styles.overflow = 'visible',styles.height='auto'), TRANSITION_TIME);
+    setTimeout(
+      () => ((styles.overflow = 'visible'), (styles.height = 'auto')),
+      TRANSITION_TIME
+    );
     emit('opened');
   } else {
     styles.overflow = 'hidden';
-    styles.height='0';
+    styles.height = '0';
     emit('closed');
   }
 };

--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -25,9 +25,9 @@
 
     <DisclosurePanel static>
       <div
-        class="relative z-10 overflow-visible"
+        class="relative z-10 overflow-hidden"
         :class="transition && transitionClass"
-        :style="{ height }"
+        :style="styles"
       >
         <div ref="content">
           <slot :open="open" />
@@ -40,7 +40,7 @@
 <script setup>
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue';
 
-import { ref, inject } from 'vue';
+import { ref, inject, reactive } from 'vue';
 import TriangleIcon from '../Icon/icons/TriangleIcon.vue';
 import { useSizeProp } from '../../composables/props.js';
 import { useSizeValue } from '../../composables/forms.js';
@@ -63,6 +63,7 @@ const emit = defineEmits(['opened', 'closed']);
 
 const initialHeight = isOpen ? 'auto' : 0;
 const height = ref(initialHeight);
+let styles = reactive({ height: initialHeight, overflow: 'hidden' });
 const content = ref(null);
 const TRANSITION_TIME = props.transition ? 400 : 0;
 
@@ -83,13 +84,15 @@ const onClick = () => {
   if (props.accordionId) accordionState[props.accordionId] = isOpen;
 
   const contentHeight = content.value.getBoundingClientRect().height;
-  height.value = contentHeight + 'px';
+  height.value = isOpen ? `${contentHeight}px` : '0';
 
   if (isOpen) {
-    setTimeout(() => (height.value = 'auto'), TRANSITION_TIME);
+    styles.height = height.value;
+    setTimeout(() => (styles.overflow = 'visible'), TRANSITION_TIME);
     emit('opened');
   } else {
-    setTimeout(() => (height.value = '0'));
+    styles.height = '0';
+    setTimeout(() => (styles.overflow = 'hidden'));
     emit('closed');
   }
 };

--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -64,7 +64,10 @@ const emit = defineEmits(['opened', 'closed']);
 const initialHeight = isOpen ? 'auto' : 0;
 const initialOverflow = isOpen ? 'visible' : 'hidden';
 const height = ref(initialHeight);
-let styles = reactive({ height: initialHeight, overflow: initialOverflow });
+const styles = reactive({
+  height: initialHeight,
+  overflow: initialOverflow,
+});
 const content = ref(null);
 const TRANSITION_TIME = props.transition ? 400 : 0;
 

--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -88,11 +88,11 @@ const onClick = () => {
 
   if (isOpen) {
     styles.height = height.value;
-    setTimeout(() => (styles.overflow = 'visible'), TRANSITION_TIME);
+    setTimeout(() => (styles.overflow = 'visible',styles.height='auto'), TRANSITION_TIME);
     emit('opened');
   } else {
-    styles.height = '0';
-    setTimeout(() => (styles.overflow = 'hidden'));
+    styles.overflow = 'hidden';
+    styles.height='0';
     emit('closed');
   }
 };

--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -62,8 +62,9 @@ let isOpen = accordionState[props.accordionId] ?? props.defaultOpen;
 const emit = defineEmits(['opened', 'closed']);
 
 const initialHeight = isOpen ? 'auto' : 0;
+const initialOverflow = isOpen ? 'visible' : 'hidden';
 const height = ref(initialHeight);
-let styles = reactive({ height: initialHeight, overflow: 'hidden' });
+let styles = reactive({ height: initialHeight, overflow: initialOverflow });
 const content = ref(null);
 const TRANSITION_TIME = props.transition ? 400 : 0;
 

--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -2,7 +2,7 @@
   <Disclosure
     as="div"
     v-slot="{ open }"
-    class="concrete__accordion"
+    class="concrete__accordion relative z-10"
     :class="textClass"
     :defaultOpen="isOpen"
   >
@@ -25,7 +25,7 @@
 
     <DisclosurePanel static>
       <div
-        class="overflow-x-hidden overflow-y-auto"
+        class="relative z-10 overflow-visible"
         :class="transition && transitionClass"
         :style="{ height }"
       >

--- a/src/components/AutoComplete/AutoComplete.vue
+++ b/src/components/AutoComplete/AutoComplete.vue
@@ -50,51 +50,51 @@
         </div>
         <transition
           enter-from-class="transition opacity-0 duration-150 ease-in -translate-y-4"
-          leave-to-class="transition opacity-0 duration-150 ease-in -translate-y-4"
+          leave-to-class="transition-opacity opacity-0 duration-150"
           enter-to-class="ease-in duration-300 ease-out opacity-100 translate-y-0"
           name="listbox"
         >
-        <ComboboxOptions
-          class="
-            absolute
-            z-10
-            mt-1
-            w-full
-            bg-white
-            shadow-lg
-            py-1
-            text-base
-            ring-1 ring-black ring-opacity-5
-            overflow-auto
-            focus:outline-none
-            sm:text-sm
-          "
-        >
-          <div
-            v-if="filteredOptions.length === 0 && searchValue !== ''"
-            class="cursor-default select-none relative py-2 pl-3 pr-9 z-20"
-            :class="textSizeClass"
+          <ComboboxOptions
+            class="
+              absolute
+              z-10
+              mt-1
+              w-full
+              bg-white
+              shadow-lg
+              py-1
+              text-base
+              ring-1 ring-black ring-opacity-5
+              overflow-auto
+              focus:outline-none
+              sm:text-sm
+            "
           >
-            {{ props.searchFailedMessage }}
-          </div>
-
-          <ComboboxOption
-            v-for="option in filteredOptions"
-            :key="option.key"
-            :value="option.value"
-            v-slot="{ active }"
-          >
-            <li
-              :class="[
-                active ? 'text-white bg-indigo' : 'text-gray-900',
-                textSizeClass,
-              ]"
+            <div
+              v-if="filteredOptions.length === 0 && searchValue !== ''"
               class="cursor-default select-none relative py-2 pl-3 pr-9 z-20"
+              :class="textSizeClass"
             >
-              {{ option.key }}
-            </li>
-          </ComboboxOption>
-        </ComboboxOptions>
+              {{ props.searchFailedMessage }}
+            </div>
+
+            <ComboboxOption
+              v-for="option in filteredOptions"
+              :key="option.key"
+              :value="option.value"
+              v-slot="{ active }"
+            >
+              <li
+                :class="[
+                  active ? 'text-white bg-indigo' : 'text-gray-900',
+                  textSizeClass,
+                ]"
+                class="cursor-default select-none relative py-2 pl-3 pr-9 z-20"
+              >
+                {{ option.key }}
+              </li>
+            </ComboboxOption>
+          </ComboboxOptions>
         </transition>
       </div>
     </Combobox>

--- a/src/components/AutoComplete/AutoComplete.vue
+++ b/src/components/AutoComplete/AutoComplete.vue
@@ -48,6 +48,12 @@
           <CInputAffix v-if="suffix" type="suffix">{{ suffix }}</CInputAffix>
           <slot name="suffix" class="z-10" />
         </div>
+        <transition
+          enter-from-class="transition opacity-0 duration-150 ease-in -translate-y-4"
+          leave-to-class="transition opacity-0 duration-150 ease-in -translate-y-4"
+          enter-to-class="ease-in duration-300 ease-out opacity-100 translate-y-0"
+          name="listbox"
+        >
         <ComboboxOptions
           class="
             absolute
@@ -89,6 +95,7 @@
             </li>
           </ComboboxOption>
         </ComboboxOptions>
+        </transition>
       </div>
     </Combobox>
   </component>

--- a/src/components/Listbox/Listbox.vue
+++ b/src/components/Listbox/Listbox.vue
@@ -67,7 +67,7 @@
 
         <transition
           enter-from-class="transition opacity-0 duration-150 ease-in -translate-y-6"
-          leave-to-class="transition opacity-0 duration-150 ease-in -translate-y-6"
+          leave-to-class="transition-opacity opacity-0 duration-150"
           enter-to-class="ease-in duration-300 ease-out opacity-100 translate-y-0"
           name="listbox"
         >

--- a/src/components/Listbox/Listbox.vue
+++ b/src/components/Listbox/Listbox.vue
@@ -1,7 +1,17 @@
 <template>
   <component
     :is="wrap ? CFormElement : CFragment"
-    v-bind="{ id, label, size, color, disabled, labelFormatter, message, stacked, noLabel }"
+    v-bind="{
+      id,
+      label,
+      size,
+      color,
+      disabled,
+      labelFormatter,
+      message,
+      stacked,
+      noLabel,
+    }"
   >
     <Listbox
       as="div"
@@ -12,59 +22,107 @@
       class="concrete__listbox"
     >
       <div :class="['relative', disabledClass]">
-        <div class="inline-flex  w-full">
+        <div class="inline-flex w-full">
           <div class="relative z-0 inline-flex w-full" :class="inputColorClass">
             <CInputAffix v-if="prefix" type="prefix">{{ prefix }}</CInputAffix>
-            <slot name="prefix" class="z-10"/>
-            <ListboxButton ref="buttonRef" :id="id"
-                           :class="[inputStaticClasses, bgColorClass, inputColorClass, mergedSizeClass, cursorClass ]">
-              <span class="block-truncate" :class="selectedLabel || 'text-gray-400'">{{ selectedLabel || placeholder }}</span>
-              <span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-                <ChevronUpDownIcon :class="[iconColorClass, iconSizeClass]" aria-hidden="true" />
+            <slot name="prefix" class="z-10" />
+            <ListboxButton
+              ref="buttonRef"
+              :id="id"
+              :class="[
+                inputStaticClasses,
+                bgColorClass,
+                inputColorClass,
+                mergedSizeClass,
+                cursorClass,
+              ]"
+            >
+              <span
+                class="block-truncate"
+                :class="selectedLabel || 'text-gray-400'"
+                >{{ selectedLabel || placeholder }}</span
+              >
+              <span
+                class="
+                  absolute
+                  inset-y-0
+                  right-0
+                  flex
+                  items-center
+                  pr-2
+                  pointer-events-none
+                "
+              >
+                <ChevronUpDownIcon
+                  :class="[iconColorClass, iconSizeClass]"
+                  aria-hidden="true"
+                />
               </span>
             </ListboxButton>
-            <input type="hidden" :value="selectedLabel" data-selected>
+            <input type="hidden" :value="selectedLabel" data-selected />
             <CInputAffix v-if="suffix" type="suffix">{{ suffix }}</CInputAffix>
-            <slot name="suffix" class="z-10"/>
+            <slot name="suffix" class="z-10" />
           </div>
         </div>
 
-        <div v-show="open">
-          <transition leave-active-class="transition ease-in duration-100" leave-from-class="opacity-100" leave-to-class="opacity-0">
-            <ListboxOptions
-              static
-              class="absolute z-30 mt-1 w-full bg-white shadow-lg py-1 ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none"
-              :class="[optionsSizeClass, maxOptionsHeightClass]"
+        <transition
+          enter-from-class="transition opacity-0 duration-150 ease-in -translate-y-6"
+          leave-to-class="transition opacity-0 duration-150 ease-in -translate-y-6"
+          enter-to-class="ease-in duration-300 ease-out opacity-100 translate-y-0"
+          name="listbox"
+        >
+          <ListboxOptions
+            class="absolute z-30 w-full bg-white shadow-lg focus:outline-none"
+            :class="[optionsSizeClass, maxOptionsHeightClass]"
+          >
+            <ListboxOption
+              as="template"
+              v-for="option in localOptions"
+              :key="option.value"
+              :value="option.value"
+              :disabled="option.disabled"
+              v-slot="{ active, selected }"
             >
-              <ListboxOption
-                as="template"
-                v-for="option in localOptions"
-                :key="option.value"
-                :value="option.value"
-                :disabled="option.disabled"
-                v-slot="{ active, selected }"
+              <li
+                :class="[
+                  active ? 'text-white bg-indigo' : 'text-gray-900',
+                  'cursor-default select-none relative py-2 pl-3 pr-8',
+                ]"
               >
-                <li :class="[active ? 'text-white bg-indigo' : 'text-gray-900', 'cursor-default select-none relative py-2 pl-3 pr-8']">
-                  <span :class="[selected ? 'font-semibold' : 'font-normal', 'block truncate']">
-                    {{ option.label }}
-                  </span>
+                <span
+                  :class="[
+                    selected ? 'font-semibold' : 'font-normal',
+                    'block truncate',
+                  ]"
+                >
+                  {{ option.label }}
+                </span>
 
-                  <span v-if="selected" :class="[active ? 'text-white' : 'text-indigo', 'absolute inset-y-0 right-0 flex items-center pr-4']">
-                    <CheckIcon class="h-5 w-5" aria-hidden="true" />
-                  </span>
-                </li>
-              </ListboxOption>
-            </ListboxOptions>
-          </transition>
-        </div>
+                <span
+                  v-if="selected"
+                  :class="[
+                    active ? 'text-white' : 'text-indigo',
+                    'absolute inset-y-0 right-0 flex items-center pr-4',
+                  ]"
+                >
+                  <CheckIcon class="h-5 w-5" aria-hidden="true" />
+                </span>
+              </li>
+            </ListboxOption>
+          </ListboxOptions>
+        </transition>
       </div>
     </Listbox>
   </component>
 </template>
 
 <script setup>
-
-import { Listbox, ListboxButton, ListboxOptions, ListboxOption, } from '@headlessui/vue';
+import {
+  Listbox,
+  ListboxButton,
+  ListboxOptions,
+  ListboxOption,
+} from '@headlessui/vue';
 import { CheckIcon, ChevronUpDownIcon } from '@heroicons/vue/24/solid';
 import { computed, ref } from 'vue';
 import { isPlainObject, isEqual } from 'lodash-es';
@@ -73,14 +131,14 @@ import {
   useInputColorClassValue,
   inputStaticClasses,
   useInputClasses,
-  useCursorClass
+  useCursorClass,
 } from '../../composables/styles.js';
 import {
   useNoWrapValue,
   useSizeValue,
   useStackedValue,
   useInputValue,
-  useRegisterInput
+  useRegisterInput,
 } from '../../composables/forms.js';
 import { useEventHandler } from '../../composables/events.js';
 import CFormElement from '../FormElement/FormElement.vue';
@@ -92,7 +150,9 @@ const props = defineProps({
   modelValue: [String, Object, Array],
   options: {
     type: Array,
-    default(rawProps) { return [] },
+    default(rawProps) {
+      return [];
+    },
   },
   multiple: { type: Boolean, default: false },
   formatter: { type: Function, default: null },
@@ -102,22 +162,20 @@ const props = defineProps({
     type: String,
     default: 'md',
     validator(value) {
-      return ['auto', 'xs', 'sm', 'md', 'lg'].includes(value)
-    }
+      return ['auto', 'xs', 'sm', 'md', 'lg'].includes(value);
+    },
   },
   onChange: { type: Function, default: null },
 });
 
 const emit = defineEmits(['update:modelValue', 'change']);
 
-const {
-  mergedSizeClass,
-  inputColorClass,
-  bgColorClass,
-} = useInputClasses(props);
-const disabledClass = computed(() => isDisabled.value && 'opacity-60')
-const cursorClass = computed(() => isDisabled.value? 'cursor-not-allowed' : 'cursor-pointer');
-
+const { mergedSizeClass, inputColorClass, bgColorClass } =
+  useInputClasses(props);
+const disabledClass = computed(() => isDisabled.value && 'opacity-60');
+const cursorClass = computed(() =>
+  isDisabled.value ? 'cursor-not-allowed' : 'cursor-pointer'
+);
 
 const size = useSizeValue(props.size);
 const stacked = useStackedValue(props.stacked);
@@ -136,38 +194,44 @@ const selectedValue = computed({
     localValue.value = value;
     emit('update:modelValue', value);
     onChange();
-  }
+  },
 });
 
 const isDisabled = computed(() => {
   return props.disabled || !localOptions.value.length;
-})
+});
 
 const onChange = useEventHandler('change', props, emit, localValue, isDirty);
-const focus = () => {  buttonRef.value.$el.focus(); }
+const focus = () => {
+  buttonRef.value.$el.focus();
+};
 defineExpose({ focus });
 
 const localOptions = computed(() => {
   return props.options.map((option) => {
-    const opt = isPlainObject(option) ? option : { label: option, value: option };
-    return props.formatter ? { ...opt, label: props.formatter(opt.label || opt.value) } : opt;
+    const opt = isPlainObject(option)
+      ? option
+      : { label: option, value: option };
+    return props.formatter
+      ? { ...opt, label: props.formatter(opt.label || opt.value) }
+      : opt;
   });
 });
 
 const selectedLabel = computed(() => {
-  let sv = selectedValue.value
+  let sv = selectedValue.value;
 
-  if(!props.multiple) {
+  if (!props.multiple) {
     if (isPlainObject(sv)) {
       return props.formatter ? props.formatter(sv) : sv;
     }
     sv = [selectedValue.value];
   }
   const labels = sv
-    .filter(selectedItem => selectedItem != null)
+    .filter((selectedItem) => selectedItem != null)
     .map((selectedItem) => {
       return localOptions.value.find((option) => {
-        return isEqual(option.value, selectedItem)
+        return isEqual(option.value, selectedItem);
       })?.label;
     });
 
@@ -179,7 +243,7 @@ const optionsSizeClass = {
   sm: 'text-sm',
   md: 'text-base',
   lg: 'text-lg',
-}[size]
+}[size];
 
 const iconSizeClass = {
   xs: 'h-3 w-3',
@@ -209,5 +273,4 @@ const iconColorClass = computed(() => {
 });
 
 useRegisterInput(props, buttonRef);
-
 </script>

--- a/src/components/Resizable/Pane.vue
+++ b/src/components/Resizable/Pane.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="concrete__pane flex-1" ref="paneRef">
+  <div class="concrete__pane" ref="paneRef">
     <slot />
   </div>
 </template>
@@ -8,7 +8,7 @@
 import { inject, ref, onMounted } from 'vue';
 
 const props = defineProps({
-  min: { type: Number, default: null, validator: (prop) => prop <= 90 },
+  min: { type: String, default: null },
   primary: { type: Boolean, default: false },
 });
 

--- a/src/components/Resizable/Resizable.vue
+++ b/src/components/Resizable/Resizable.vue
@@ -57,8 +57,8 @@ const containerRef = ref(null);
 let leftMinWidth;
 let rightMinWidth;
 let currDrag;
-let primaryPaneIndex;
-let leftIsPrimary;
+let primaryPaneIndex = 0;
+let leftIsPrimary = true;
 let dragging = false;
 
 const leftPane = computed(() => panes.value[0]);
@@ -156,7 +156,7 @@ const validateMinProps = () => {
   const containerWidth = containerClientRect.value.width;
 
   if (leftIsPrimary) {
-    rightMinWidth = rightPane.value.min || containerWidth / 2;
+    rightMinWidth = rightPane.value.min || containerWidth * 0.25;
 
     if (leftPane.value.usePercent) {
       //percent
@@ -166,10 +166,10 @@ const validateMinProps = () => {
           : containerWidth * (leftPane.value.min / 100);
     } else {
       //pixels
-      leftMinWidth = leftPane.value.min || containerWidth / 2;
+      leftMinWidth = leftPane.value.min || containerWidth * 0.25;
     }
   } else {
-    leftMinWidth = leftPane.value.min || containerWidth / 2;
+    leftMinWidth = leftPane.value.min || containerWidth * 0.25;
     if (rightPane.value.usePercent) {
       //percent
       rightMinWidth =
@@ -178,7 +178,7 @@ const validateMinProps = () => {
           : containerWidth * (rightPane.value.min / 100);
     } else {
       //pixels
-      rightMinWidth = rightPane.value.min || containerWidth / 2;
+      rightMinWidth = rightPane.value.min || containerWidth * 0.25;
     }
   }
 };

--- a/src/components/Resizable/Resizable.vue
+++ b/src/components/Resizable/Resizable.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="containerRef"
-    class="concrete__resizable relative overflow-hidden"
+    class="concrete__resizable relative overflow-hidden w-full"
     draggable="false"
     @mousemove="drag"
     @mouseup="endDrag"

--- a/src/components/Resizable/Resizable.vue
+++ b/src/components/Resizable/Resizable.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="containerRef"
-    class="concrete__resizable relative overflow-hidden w-full"
+    class="concrete__resizable relative overflow-hidden"
     draggable="false"
     @mousemove="drag"
     @mouseup="endDrag"


### PR DESCRIPTION
Added transition effects to Autocomplete (contains Combobox) and Listbox. Note that the Accordion control has been revised to accept an overflowing object (the Listbox) and as such now toggles its own overflow state.

Latest branch of column shoes (fix/add-state-to-accordions) uses these revised widgets, should you wish to test them in context.

Added tweaks to solve some Resizable bugs that have been found also.