### PR TITLE
fix: transition edits

### DIFF
--- a/src/components/AutoComplete/AutoComplete.vue
+++ b/src/components/AutoComplete/AutoComplete.vue
@@ -50,7 +50,7 @@
         </div>
         <transition
           enter-from-class="transition opacity-0 duration-150 ease-in -translate-y-4"
-          leave-to-class="transition-opacity opacity-0 duration-150"
+          leave-to-class="transition opacity-0 duration-150"
           enter-to-class="ease-in duration-300 ease-out opacity-100 translate-y-0"
           name="listbox"
         >

--- a/src/components/Listbox/Listbox.vue
+++ b/src/components/Listbox/Listbox.vue
@@ -19,7 +19,7 @@
       :disabled="isDisabled"
       :multiple="multiple"
       v-slot="{ open }"
-      class="concrete__listbox x"
+      class="concrete__listbox"
     >
       <div :class="['relative', disabledClass]">
         <div class="inline-flex w-full">
@@ -67,7 +67,7 @@
 
         <transition
           enter-from-class="transition opacity-0 duration-150 ease-in -translate-y-6"
-          leave-to-class="transition-opacity opacity-0 duration-150"
+          leave-to-class="transition opacity-0 duration-150"
           enter-to-class="ease-in duration-300 ease-out opacity-100 translate-y-0"
           name="listbox"
         >


### PR DESCRIPTION
Setting the transition to just opacity shows the top of the moving element too early. Adjusted to suit.

Also, first real test of new release please GitHub action.