### PR TITLE
fix: fixed listbox overflow issue with accordion

### DIFF
--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -2,7 +2,7 @@
   <Disclosure
     as="div"
     v-slot="{ open }"
-    class="concrete__accordion relative z-10"
+    class="concrete__accordion relative"
     :class="textClass"
     :defaultOpen="isOpen"
   >
@@ -25,7 +25,7 @@
 
     <DisclosurePanel static>
       <div
-        class="relative z-10 overflow-hidden"
+        class="relative overflow-y-auto"
         :class="transition && transitionClass"
         :style="styles"
       >

--- a/src/components/Listbox/Listbox.vue
+++ b/src/components/Listbox/Listbox.vue
@@ -11,7 +11,7 @@
       message,
       stacked,
       noLabel,
-      tooltip
+      tooltip,
     }"
   >
     <Listbox

--- a/src/components/Listbox/Listbox.vue
+++ b/src/components/Listbox/Listbox.vue
@@ -72,15 +72,7 @@
           name="listbox"
         >
           <ListboxOptions
-            class="
-              absolute
-              z-30
-              w-full
-              bg-white
-              shadow-lg
-              focus:outline-none
-              overflow-y-auto
-            "
+            class="absolute z-30 w-full bg-white shadow-lg focus:outline-none overflow-y-auto"
             :class="[optionsSizeClass, maxOptionsHeightClass]"
           >
             <ListboxOption

--- a/src/components/Listbox/Listbox.vue
+++ b/src/components/Listbox/Listbox.vue
@@ -72,7 +72,15 @@
           name="listbox"
         >
           <ListboxOptions
-            class="absolute z-50 w-full bg-white shadow-lg focus:outline-none overflow-y-auto"
+            class="
+              absolute
+              z-30
+              w-full
+              bg-white
+              shadow-lg
+              focus:outline-none
+              overflow-y-auto
+            "
             :class="[optionsSizeClass, maxOptionsHeightClass]"
           >
             <ListboxOption

--- a/src/components/Listbox/Listbox.vue
+++ b/src/components/Listbox/Listbox.vue
@@ -11,6 +11,7 @@
       message,
       stacked,
       noLabel,
+      tooltip
     }"
   >
     <Listbox

--- a/src/components/Listbox/Listbox.vue
+++ b/src/components/Listbox/Listbox.vue
@@ -11,7 +11,6 @@
       message,
       stacked,
       noLabel,
-      tooltip,
     }"
   >
     <Listbox
@@ -73,7 +72,7 @@
           name="listbox"
         >
           <ListboxOptions
-            class="absolute z-30 w-full bg-white shadow-lg focus:outline-none overflow-y-auto"
+            class="absolute z-50 w-full bg-white shadow-lg focus:outline-none overflow-y-auto"
             :class="[optionsSizeClass, maxOptionsHeightClass]"
           >
             <ListboxOption


### PR DESCRIPTION
Fixed the overflow and z-index issues when listbox is inside an accordion. Please check this in column shoes, for example.