### PR TITLE
fix: resize bug

### DIFF
--- a/src/components/Resizable/Resizable.vue
+++ b/src/components/Resizable/Resizable.vue
@@ -118,10 +118,11 @@ const registerPane = (pane) => {
 
 const handleResize = () => {
   setPaneWidths();
-
+  if(splitter.value){
   splitter.value.style.left = `${
     leftPane.value.el.getBoundingClientRect().width - splitterWidth.value
   }px`;
+}
 };
 
 const setPaneWidths = () => {
@@ -146,10 +147,11 @@ const initialSetup = () => {
   if (primaryPaneIndex !== 0) leftIsPrimary = false;
 
   validateMinProps();
-
+  if(splitter.value){
   splitter.value.style.left = `${
     leftPane.value.el.getBoundingClientRect().width - splitterWidth.value
   }px`;
+}
 };
 
 const validateMinProps = () => {


### PR DESCRIPTION
Now that switching languages is available in column shoes, an error is raised on the resize event. Now wrapped in an if block.