### PR TITLE
fix: redraw on drag

### DIFF
--- a/src/components/Resizable/Resizable.vue
+++ b/src/components/Resizable/Resizable.vue
@@ -29,7 +29,7 @@
   -ms-user-select: none;
   user-select: none;
   cursor: col-resize;
-  z-index: 69;
+  z-index: 2;
   height: 100%;
 }
 
@@ -97,6 +97,8 @@ const endDrag = () => {
 const drag = (e) => {
   if (dragging) {
     currDrag = getCurrentMouseDrag(e).x;
+    
+  handleResize();
     splitter.value.style.left = `${currDrag - splitterWidth.value}px`;
   }
 };


### PR DESCRIPTION
Revised z-index of separator as e2e tests reported this covering modal elements - modal z-index was recently changed.
Also set to redraw whilst dragging and not just when drag end.