### PR TITLE
fix: remove checkout outline on click

### DIFF
--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -28,15 +28,14 @@
         ref="switchRef"
         :disabled="disabled"
         :id="id"
-        @click="onClick"
+        @mousedown="onMouseDown"
+        @mouseup="onMouseUp"
         v-model="enabled"
         class="
           items-center
           border border-gray-300
-          focus:ring
-          focus:outline-none
         "
-        :class="[`h-${sized} w-${sized}`, cursorClass, styleClass]"
+        :class="[`h-${sized} w-${sized}`, outlineClass, cursorClass, styleClass]"
       >
         <span class="flex justify-center transition-opacity p-[2px]">
           <CheckIcon v-if="enabled" />
@@ -85,6 +84,7 @@ const wrap = !useNoWrapValue(props);
 const switchRef = ref(null);
 const isDirty = ref(false);
 const localValue = ref(null);
+const preventOutline = ref(null);
 
 const enabled = computed({
   get() {
@@ -134,7 +134,19 @@ const styleClass = computed(() => {
 
 useRegisterInput(props, switchRef);
 
-const onClick = (_event) => switchRef.value.el.blur();
+const onMouseDown = (_event) => preventOutline.value = true;
+const onMouseUp = (_event) => {
+  preventOutline.value = false;
+  switchRef.value.el.blur();
+};
+
+const outlineClass = computed(() => {
+  if(preventOutline.value) {
+    return 'focus:outline-none'
+  } else {
+    return 'focus:ring'
+  }
+});
 
 // The Switch component does not accept an id prop
 // so we need to override headless UI's default id

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -140,13 +140,7 @@ const onMouseUp = (_event) => {
   switchRef.value.el.blur();
 };
 
-const outlineClass = computed(() => {
-  if(preventOutline.value) {
-    return 'focus:outline-none'
-  } else {
-    return 'focus:ring'
-  }
-});
+const outlineClass = computed(() => preventOutline.value ? 'focus:outline-none' : 'focus:ring');
 
 // The Switch component does not accept an id prop
 // so we need to override headless UI's default id

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -35,6 +35,7 @@
         class="
           items-center
           border border-gray-300
+          focus:outline-none
         "
         :class="[`h-${sized} w-${sized}`, outlineClass, cursorClass, styleClass]"
       >
@@ -138,7 +139,7 @@ useRegisterInput(props, switchRef);
 const onMouseDown = (_event) => preventOutline.value = true;
 const onKeyUp = (_event) => preventOutline.value = false;
 
-const outlineClass = computed(() => preventOutline.value ? 'focus:outline-none' : 'focus:ring');
+const outlineClass = computed(() => !preventOutline.value && 'focus:ring');
 
 // The Switch component does not accept an id prop
 // so we need to override headless UI's default id

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -28,6 +28,7 @@
         ref="switchRef"
         :disabled="disabled"
         :id="id"
+        @click="onClick"
         v-model="enabled"
         class="
           items-center
@@ -132,6 +133,8 @@ const styleClass = computed(() => {
 });
 
 useRegisterInput(props, switchRef);
+
+const onClick = (_event) => switchRef.value.el.blur();
 
 // The Switch component does not accept an id prop
 // so we need to override headless UI's default id

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -15,7 +15,8 @@
       labelOrder: reverseLabels ? 1 : 0,
       labelClass,
       tooltip,
-      cssClass
+      cssClass,
+      onMouseDown
     }"
     :class="{ '!justify-start': reverseLabels }"
   >
@@ -29,7 +30,7 @@
         :disabled="disabled"
         :id="id"
         @mousedown="onMouseDown"
-        @mouseup="onMouseUp"
+        @keyup.tab="onKeyUp"
         v-model="enabled"
         class="
           items-center
@@ -135,10 +136,7 @@ const styleClass = computed(() => {
 useRegisterInput(props, switchRef);
 
 const onMouseDown = (_event) => preventOutline.value = true;
-const onMouseUp = (_event) => {
-  preventOutline.value = false;
-  switchRef.value.el.blur();
-};
+const onKeyUp = (_event) => preventOutline.value = false;
 
 const outlineClass = computed(() => preventOutline.value ? 'focus:outline-none' : 'focus:ring');
 

--- a/src/components/FormElement/FormElement.vue
+++ b/src/components/FormElement/FormElement.vue
@@ -12,6 +12,7 @@
           class="leading-5 whitespace-nowrap w-full"
           :class="[lineClampClass, labelClass]"
           :for="id"
+          @mousedown="props.onMouseDown?.()"
         >
           {{ label }}
         </label>
@@ -52,6 +53,7 @@ const props = defineProps({
   labelOrder: { type: Number },
   labelClass: String,
   tooltip: String,
+  onMouseDown: Function
 });
 
 const LABEL_ORDER_CLASSES = {


### PR DESCRIPTION
Prevent checkout outline on mouse click but make sure that input is still focusable using tab key.