### PR TITLE
feat: enable label with subscript or superscript in table header

### DIFF
--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -6,9 +6,7 @@
     @click="$emit('click', $event)"
     class="concrete__button"
   >
-    <div>
-      <slot />
-    </div>
+    <slot />
   </button>
 </template>
 

--- a/src/components/Table/Table.vue
+++ b/src/components/Table/Table.vue
@@ -13,7 +13,12 @@
             @click="() => col.sortable && toggleSort(col.id)"
           >
             <slot :name="`${col.id}.header`">
-              <span :class="col.label || 'uppercase'">
+              <span v-if="col.label?.name" v-for="(label, propertyName) in col.label">
+                <sup v-if="propertyName === 'sup'">{{label}} </sup>
+                <sub v-else-if="propertyName === 'sub'">{{label}} </sub>
+                <span v-else>{{label}}</span>
+              </span>
+              <span v-else :class="col.label || 'uppercase'">
                 {{ col.label || startCase(col.id) }}
               </span>
             </slot>

--- a/src/components/Table/Table.vue
+++ b/src/components/Table/Table.vue
@@ -13,11 +13,7 @@
             @click="() => col.sortable && toggleSort(col.id)"
           >
             <slot :name="`${col.id}.header`">
-              <span v-if="col.label?.name" v-for="(label, propertyName) in col.label">
-                <sup v-if="propertyName === 'sup'">{{label}} </sup>
-                <sub v-else-if="propertyName === 'sub'">{{label}} </sub>
-                <span v-else>{{label}}</span>
-              </span>
+              <span v-if="col.label?.html" v-html="col.label?.html"></span>
               <span v-else :class="col.label || 'uppercase'">
                 {{ col.label || startCase(col.id) }}
               </span>

--- a/src/components/Table/__stories__/Table.stories.mdx
+++ b/src/components/Table/__stories__/Table.stories.mdx
@@ -61,7 +61,11 @@ export const componentTemplate = (args) => ({
       return Object.values(this.team);
     },
     columns() {
-      return [{ id: 'name', sortable: true }, { id: 'role' }];
+      return [
+        { id: 'name', sortable: true }, { id: 'role' }, 
+        {id: 'subTest', label: {name: 'V', sub: '1234', space: ' ', unit: '[kN]' }},
+        {id: 'supTest', label: {name: 'S', sup: '1234', space: ' ', unit: '[kN]' }}
+      ];
     },
   },
   template: `

--- a/src/components/Table/__stories__/Table.stories.mdx
+++ b/src/components/Table/__stories__/Table.stories.mdx
@@ -21,13 +21,13 @@ export const componentTemplate = (args) => ({
   },
   data() {
     const team = {
-      1: { id: 1, name: 'lee', role: 'developer', isSelected: false },
-      2: { id: 2, name: 'matt', role: 'developer', isSelected: true },
-      3: { id: 3, name: 'dan', role: 'developer', isSelected: false },
-      4: { id: 4, name: 'yaming', role: 'developer', isSelected: false },
-      5: { id: 5, name: 'pete', role: 'developer', isSelected: false },
-      6: { id: 6, name: 'calum', role: 'developer', isSelected: false },
-      7: { id: 7, name: 'robi', role: 'developer', isSelected: false },
+      1: { id: 1, name: 'lee', role: 'developer', labelHtml:'Sub and Super script', isSelected: false },
+      2: { id: 2, name: 'matt', role: 'developer', labelHtml:'Sub and Super script', isSelected: true },
+      3: { id: 3, name: 'dan', role: 'developer', labelHtml:'Sub and Super script', isSelected: false },
+      4: { id: 4, name: 'yaming', role: 'developer', labelHtml:'Sub and Super script', isSelected: false },
+      5: { id: 5, name: 'pete', role: 'developer', labelHtml:'Sub and Super script', isSelected: false },
+      6: { id: 6, name: 'calum', role: 'developer', labelHtml:'Sub and Super script', isSelected: false },
+      7: { id: 7, name: 'robi', role: 'developer', labelHtml:'Sub and Super script', isSelected: false },
     };
     return { team };
   },
@@ -63,8 +63,7 @@ export const componentTemplate = (args) => ({
     columns() {
       return [
         { id: 'name', sortable: true }, { id: 'role' }, 
-        {id: 'subTest', label: {name: 'V', sub: '1234', space: ' ', unit: '[kN]' }},
-        {id: 'supTest', label: {name: 'S', sup: '1234', space: ' ', unit: '[kN]' }}
+        {id: 'labelHtml', label: {html: '<span>V<sup>3</sup><sub>Ed</sub>[kN]</span>' }},
       ];
     },
   },


### PR DESCRIPTION
The idea to enable subscript and superscript for table header label is to change how we are going to get the label from the columns prop. 
Instead of getting it as a string like we are getting it now:
[ { id: 'label1', label: 'label1' },  { id: 'label2', label: 'label2' } ] 
The proposed solution would be to get the label as an object with the html property that would be a string containing the needed order and sub or sup scripts:
[ 
   {id: 'labelHtml', label: {html: `<span>V<sup>3</sup><sub>Ed</sub>[kN]</span>` }}
]
  