### PR TITLE
fix: default empty text to zero

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -87,7 +87,12 @@
                   <div class="bg-blue-300 p-1 mb-1">
                     Input with prefix and suffix
                   </div>
-                  <CTextInput id="Width" prefix="w" suffix="mm" />
+                  <CNumericInput
+                    id="width"
+                    prefix="w"
+                    suffix="mm"
+                    :minimum="200"
+                  />
                 </div>
 
                 <div>
@@ -122,26 +127,22 @@
               </div>
               <div>
                 <div class="bg-blue-300 p-1 mb-1">Numeric Inputs</div>
+                <CNumericInput label="Spinner (no override, default)" unit="mm">
+                </CNumericInput>
                 <CNumericInput
-                label="Spinner (no override, default)"
-                unit="mm"
-                >
-              </CNumericInput>
-                <CNumericInput
-                label="No Spinner (override, default)"
-                unit="mm"
-                :spinner="false"
+                  label="No Spinner (override, default)"
+                  unit="mm"
+                  :spinner="false"
                 >
                 </CNumericInput>
                 <CNumericInput
-                label="Spinner (override, default)"
-                unit="mm"
-                :spinner="true"
+                  label="Spinner (override, default)"
+                  unit="mm"
+                  :spinner="true"
                 >
                 </CNumericInput>
               </div>
             </div>
-
           </CFormSection>
           <CFormSection class="">
             <div class="flex space-x-16">
@@ -319,7 +320,6 @@
               size="xs"
             />
           </div>
-
         </div>
       </div>
     </div>
@@ -382,13 +382,7 @@ export default {
       ButtonGroupValue: 'Option 2',
       RadioGroupIdOptions: 'Option 2',
       ButtonGroupIdOptions: 'Option 2',
-      Options: [
-        'Option 1',
-        'Option 2',
-        'Option 3',
-        'Option 4',
-        'Option 5',
-      ],
+      Options: ['Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5'],
       OptionsObjects: [
         { label: 'Option 1', value: 'Option 1', disabled: false },
         { label: 'Option 2', value: 'Option 2', disabled: false },

--- a/src/main.js
+++ b/src/main.js
@@ -19,22 +19,23 @@ const store = reactive({
   isAdmin: false,
   buttonGroup: options,
   radioGroup: options,
-  options: options
+  options: options,
+  width: 200,
 });
 
 const statusStore = reactive({
   firstname: {
     type: 'error',
-    message: 'Users called John are not allowed here'
+    message: 'Users called John are not allowed here',
   },
   lastname: {
     type: 'warning',
-    message: 'The surname Smith is permitted, but frowned upon'
+    message: 'The surname Smith is permitted, but frowned upon',
   },
   nationality: {
     type: 'info',
-    message: 'where are you from?'
-  }
+    message: 'where are you from?',
+  },
 });
 
 window.statusStore = statusStore;
@@ -42,7 +43,7 @@ window.statusStore = statusStore;
 const app = createApp(App);
 concrete.install(app, {
   inputIdToValue: (id) => {
-    return store[id]
+    return store[id];
   },
   inputHandler: (id, value) => {
     if (!Object.hasOwn(store, id)) return;
@@ -57,11 +58,10 @@ concrete.install(app, {
 
     return () => {
       console.log(`Deregistered input with id '${id}'`);
-    }
+    };
   },
   inputGetStatus(id) {
     return statusStore[id];
   },
 });
 app.mount('#app');
-


### PR DESCRIPTION
If a user clears a numeric input then the blank text is still parsed and a number is expected - this will oftentimes throw errors. Some clients want this behaviour but we do not want this by default. Therefore, the code has been revised to capture input changes and replace an empty field with these rules:

prop "nullable" exists = return null (as before)
prop "minimum" exists = return the minimum value
none of the above = return a zero

The key change here is that clients that want a null returned must now explicitily pass a nullable prop.