### PR TITLE
feat: enable sub and sup script for input labels

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -141,6 +141,10 @@
                   :spinner="true"
                 >
                 </CNumericInput>
+                <CNumericInput label="Label with <sup>SupScript</sup>" unit="mm">
+                </CNumericInput>
+                <CNumericInput label="Label with <sub>SubScript</sub>" unit="mm">
+                </CNumericInput>
               </div>
             </div>
           </CFormSection>

--- a/src/components/FormElement/FormElement.vue
+++ b/src/components/FormElement/FormElement.vue
@@ -13,9 +13,8 @@
           :class="[lineClampClass, labelClass]"
           :for="id"
           @mousedown="props.onMouseDown?.()"
-        >
-          {{ label }}
-        </label>
+          v-html="label"
+        />
         <CTooltipIcon v-if="props.tooltip" :class="{ 'pr-2' : !stacked }" :size="size" v-tooltip="props.tooltip"/>
       </div>
     </div>


### PR DESCRIPTION
Enable sub and sup script for input labels by adding v-html attribute to label tag.
In order to have sub/sup script now we can pass the label like this label="Label with <sup>SupScript</sup>"
and it would be rendered as 
![Screenshot 2024-01-12 at 13 59 58](https://github.com/leviat-tech/concrete/assets/127110852/710d366d-5d67-44fe-94b5-929b417b3fac)
