### PR TITLE
fix: removed unwanted padding

### DIFF
--- a/src/components/RadioGroup/RadioGroup.vue
+++ b/src/components/RadioGroup/RadioGroup.vue
@@ -21,7 +21,7 @@
       :class="[textSizeClass, disabledClass]"
     >
       <RadioGroup
-        class="concrete__radiogroup space-x-2"
+        class="concrete__radiogroup"
         v-model="value"
         ref="el"
         :disabled="disabled"
@@ -72,12 +72,12 @@
 </template>
 
 <script setup>
-import { RadioGroup, RadioGroupOption } from "@headlessui/vue";
-import CFormElement from "../FormElement/FormElement.vue";
-import CFragment from "../Fragment/Fragment.vue";
-import { computed, ref } from "vue";
-import { formElementProps } from "../../composables/props";
-import { useInputClasses } from "../../composables/styles";
+import { RadioGroup, RadioGroupOption } from '@headlessui/vue';
+import CFormElement from '../FormElement/FormElement.vue';
+import CFragment from '../Fragment/Fragment.vue';
+import { computed, ref } from 'vue';
+import { formElementProps } from '../../composables/props';
+import { useInputClasses } from '../../composables/styles';
 import {
   useNoWrapValue,
   useInputValue,
@@ -85,8 +85,8 @@ import {
   useStackedValue,
   useInputIdToOptions,
   useSizeValue,
-} from "../../composables/forms.js";
-import { useEventHandler } from "../../composables/events.js";
+} from '../../composables/forms.js';
+import { useEventHandler } from '../../composables/events.js';
 
 const props = defineProps({
   ...formElementProps,
@@ -107,7 +107,7 @@ const value = computed({
   set(value) {
     isDirty.value = true;
     localValue.value = value;
-    emit("update:modelValue", value);
+    emit('update:modelValue', value);
     onChange();
   },
 });
@@ -119,10 +119,8 @@ const el = ref(null);
 const size = useSizeValue(props.size);
 const optionsClass = props.optionsClass;
 
-const xPadding = computed(() => (props.reverseLabels ? "" : "px-1"));
-
-const emit = defineEmits(["update:modelValue", "change"]);
-const onChange = useEventHandler("change", props, emit, localValue, isDirty);
+const emit = defineEmits(['update:modelValue', 'change']);
+const onChange = useEventHandler('change', props, emit, localValue, isDirty);
 useRegisterInput(props, el);
 
 const stacked = useStackedValue(props.stacked);
@@ -131,22 +129,22 @@ const wrap = !useNoWrapValue(props);
 const { inputColorClass, disabledClass, textSizeClass, heightClass } =
   useInputClasses(props);
 
-const iconSizeClass = size === "xs" ? "w-6 h-6" : heightClass;
+const iconSizeClass = size === 'xs' ? 'w-6 h-6' : heightClass;
 
 const layoutClass = computed(() => {
   if (props.columns > 0) return `grid grid-flow-row grid-cols-${props.columns}`;
-  return `flex flex-wrap justify-end ${props.reverseLabels ? "" : "px-1"}`;
+  return `flex flex-wrap justify-end ${props.reverseLabels ? '' : 'px-1'}`;
 });
 
 const svgColour = computed(() => {
   return props.color
-    ? "stroke-" + props.color + " fill-" + props.color
-    : "stroke-black fill-black";
+    ? 'stroke-' + props.color + ' fill-' + props.color
+    : 'stroke-black fill-black';
 });
 
 const labelClasses = computed(() => {
   if (!props.reverseLabels) return;
-  return "order-2 !ml-0 mr-2";
+  return 'order-2 !ml-0 mr-2';
 });
 
 const opts = computed(() => useInputIdToOptions(props));


### PR DESCRIPTION
When radio group items drop due to not enough space, the x-padding goes with the item regardless leaving unwanted left padding. This fix removes this. Tested against both CiC and Column shoes projects.

OLD
![live](https://github.com/leviat-tech/concrete/assets/55240533/a63d010b-6243-4b03-92a3-99e92334a5c0)

NEW 
![new](https://github.com/leviat-tech/concrete/assets/55240533/61db6de4-422c-41ad-958b-4b5f65c769fa)

