### PR TITLE
fix: make autocomplete options scrollable

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -120,8 +120,9 @@
               <div>
                 <div class="bg-blue-300 p-1 mb-1">Autocomplete</div>
                 <CAutoComplete
-                  :options="['a', 'b', 'aa', 'bb', 'ab']"
-                  placeholder="Enter 'a' or 'b'"
+                 :options="['a', 'aa', 'aaa', 'aaa', 'aba', 'aca', 'b', 'aa', 'bb', 'ab', 'ba']"
+                 placeholder="Enter 'a' or 'b'"
+                 :listSize="-1"
                 >
                 </CAutoComplete>
               </div>

--- a/src/components/AutoComplete/AutoComplete.vue
+++ b/src/components/AutoComplete/AutoComplete.vue
@@ -56,23 +56,23 @@
           enter-to-class="ease-in duration-300 ease-out opacity-100 translate-y-0"
           name="listbox"
         >
-        <ComboboxOptions
-          class="
-            absolute
-            mt-1
-            w-full
-            bg-white
-            shadow-lg
-            py-1
-            text-base
-            ring-1 ring-black ring-opacity-5
-            overflow-auto
-            focus:outline-none
-            sm:text-sm
-            h-[184px]
-            overflow-x-scroll
-          "
-          :class="open ? 'z-30' : 'z-10'"
+          <ComboboxOptions
+            class="
+              absolute
+              mt-1
+              w-full
+              bg-white
+              shadow-lg
+              py-1
+              text-base
+              ring-1 ring-black ring-opacity-5
+              overflow-auto
+              focus:outline-none
+              sm:text-sm
+              h-[9lh]
+              overflow-x-scroll
+            "
+            :class="open ? 'z-30' : 'z-10'"
           >
             <div
               v-if="filteredOptions.length === 0 && searchValue !== ''"

--- a/src/components/AutoComplete/AutoComplete.vue
+++ b/src/components/AutoComplete/AutoComplete.vue
@@ -69,6 +69,8 @@
             overflow-auto
             focus:outline-none
             sm:text-sm
+            h-[184px]
+            overflow-x-scroll
           "
           :class="open ? 'z-30' : 'z-10'"
           >

--- a/src/components/AutoComplete/AutoComplete.vue
+++ b/src/components/AutoComplete/AutoComplete.vue
@@ -69,7 +69,7 @@
               overflow-auto
               focus:outline-none
               sm:text-sm
-              h-[9lh]
+              h-[10lh]
               overflow-x-scroll
             "
             :class="open ? 'z-30' : 'z-10'"


### PR DESCRIPTION
Set height of autocomplete options to 5 elements with scroll options 

https://github.com/leviat-tech/concrete/assets/87523973/a4d49041-8861-4d0d-9a20-d617d962ff3c

