### PR TITLE
feat: added full width prop to viewport container

### DIFF
--- a/src/components/Viewport/ViewportContainer.vue
+++ b/src/components/Viewport/ViewportContainer.vue
@@ -56,6 +56,7 @@ export default {
   props: {
     options: { type: Array, default: () => [] },
     modelValue: { type: [String, Number], default: null },
+    forceFullWidth:{ type:Boolean },
 
     // A target aspect ratio for each viewport;
     // Used to determine how to tile multiple viewports.
@@ -72,10 +73,10 @@ export default {
   },
   computed: {
     fullWidth() {
-      return this.reactive.maximized || this.options.length < 2;
+      return this.forceFullWidth || this.reactive.maximized || this.options.length < 2;
     },
     colStyle() {
-      return `repeat(${this.cols}, minmax(0, 1fr))`;
+      return `repeat(${this.cols}, minmax(${this.forceFullWidth ? '1fr' : '0'}}, 1fr))`;
     },
   },
   watch: {

--- a/src/components/Viewport/ViewportContainer.vue
+++ b/src/components/Viewport/ViewportContainer.vue
@@ -86,9 +86,7 @@ export default {
       );
     },
     colStyle() {
-      return `repeat(${this.cols}, minmax(${
-        this.forceFullWidth ? '1fr' : '0'
-      }}, 1fr))`;
+      return `repeat(${this.cols}, minmax(0, 1fr))`;
     },
   },
   watch: {

--- a/src/components/Viewport/ViewportContainer.vue
+++ b/src/components/Viewport/ViewportContainer.vue
@@ -1,14 +1,21 @@
 <template>
   <div
     ref="viewportContainer"
-    class="concrete__viewport-container w-full h-full flex items-center justify-center overflow-hidden"
+    class="
+      concrete__viewport-container
+      w-full
+      h-full
+      flex
+      items-center
+      justify-center
+      overflow-hidden
+    "
     :class="{ 'grid bg-gray-200': !fullWidth }"
     :style="{ 'grid-template-columns': colStyle }"
   >
     <slot />
   </div>
 </template>
-
 
 <style lang="scss" scoped>
 .concrete__viewport-container {
@@ -50,13 +57,12 @@ function columns(ar, aspectRatio, options) {
   return Math.max(high, 1);
 }
 
-
 export default {
   name: 'CViewportContainer',
   props: {
     options: { type: Array, default: () => [] },
     modelValue: { type: [String, Number], default: null },
-    forceFullWidth:{ type:Boolean },
+    forceFullWidth: { type: Boolean },
 
     // A target aspect ratio for each viewport;
     // Used to determine how to tile multiple viewports.
@@ -73,10 +79,16 @@ export default {
   },
   computed: {
     fullWidth() {
-      return this.forceFullWidth || this.reactive.maximized || this.options.length < 2;
+      return (
+        this.forceFullWidth ||
+        this.reactive.maximized ||
+        this.options.length < 2
+      );
     },
     colStyle() {
-      return `repeat(${this.cols}, minmax(${this.forceFullWidth ? '1fr' : '0'}}, 1fr))`;
+      return `repeat(${this.cols}, minmax(${
+        this.forceFullWidth ? '1fr' : '0'
+      }}, 1fr))`;
     },
   },
   watch: {


### PR DESCRIPTION
Added a prop to force full width (ignoring responsive calculation). This is to support the titan task: 

https://crhleviat.atlassian.net/jira/software/c/projects/DCAT/boards/64?selectedIssue=DT-608

Please check this using titan as the callee project, branch:  DT-608-viewport-height

OLD:
![live](https://github.com/leviat-tech/concrete/assets/55240533/f1913a5e-0297-4385-a1b7-75c837c181f4)


NEW:
![new](https://github.com/leviat-tech/concrete/assets/55240533/3e34de8a-0ed3-4751-9614-c107241168c8)

