### PR TITLE
fix: issue with autocomplete input not triggering API calls on when typing

### DIFF
--- a/src/components/AutoComplete/AutoComplete.vue
+++ b/src/components/AutoComplete/AutoComplete.vue
@@ -33,6 +33,7 @@
             @click="$event.target.select()"
             @blur="$emit('blur')"
             @focus="$emit('focus')"
+            @input="onInput"
             :disabled="disabled"
             :placeholder="placeholder"
             :class="[
@@ -162,7 +163,7 @@ const {
   getStackedValue,
 } = useConcreteForms();
 
-const emit = defineEmits(['update:modelValue', 'change', 'focus', 'blur']);
+const emit = defineEmits(['update:modelValue', 'change', 'focus', 'blur', 'search']);
 
 const inputRef = ref(null);
 const stacked = getStackedValue(props.stacked);
@@ -192,6 +193,11 @@ const displayValue = computed({
     onChange();
   },
 });
+
+const onInput = (event) => {
+  searchValue.value = event.target.value;
+  emit('search', searchValue.value);
+};
 
 const localOptions = computed(() => {
   return props.options.map((o) => {


### PR DESCRIPTION
The issue that we have currently on the design studio is that we are not triggering the API call to get projects that include input search and we are just stuck with the first 5 that we fetched. 

https://github.com/user-attachments/assets/0c23a8bf-ddb3-4169-a4de-001e3ef2740d

